### PR TITLE
Update for DT 0.10.0 beta 27 and other fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,9 +111,9 @@ dependencies {
     runtimeOnly fg.deobf("mcp.mobius.waila:Hwyla:${config.hwyla_version}")
 
     // Compile JEI API, but don't include in runtime.
-    compileOnly fg.deobf("mezz.jei:jei-1.16.4:${config.jei_version}:api")
+    compileOnly fg.deobf("mezz.jei:jei-1.16.5:${config.jei_version}:api")
     // At runtime, use the full JEI mod.
-    runtimeOnly fg.deobf("mezz.jei:jei-1.16.4:${config.jei_version}")
+    runtimeOnly fg.deobf("mezz.jei:jei-1.16.5:${config.jei_version}")
 
     // Compile Dynamic Trees, of course.
     implementation fg.deobf("com.ferreusveritas.dynamictrees:DynamicTrees-${config.mc_version}:${config.dynamic_trees_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ mod_version=2.0.7
 package_group=therealeststu.dtbop
 
 mc_version=1.16.5
-forge_version=36.1.0
+forge_version=36.2.22
 
-dynamic_trees_version=0.10.0-Beta26
+dynamic_trees_version=0.10.0-Beta27-Pre5
 dynamic_trees_plus_version=0.1.0-Beta11
 hwyla_version=1.10.11-B78_1.16.2
-jei_version=7.6.1.71
+jei_version=7.7.1.139
 suggestion_provider_fix_version=1.0.0
 
 org.gradle.jvmargs=-Xmx3G

--- a/src/main/java/therealeststu/dtbop/DynamicTreesBOP.java
+++ b/src/main/java/therealeststu/dtbop/DynamicTreesBOP.java
@@ -1,25 +1,14 @@
 package therealeststu.dtbop;
 
-import com.ferreusveritas.dynamictrees.DynamicTrees;
 import com.ferreusveritas.dynamictrees.api.GatherDataHelper;
 import com.ferreusveritas.dynamictrees.api.registry.RegistryHandler;
 import com.ferreusveritas.dynamictrees.blocks.leaves.LeavesProperties;
 import com.ferreusveritas.dynamictrees.blocks.rootyblocks.SoilProperties;
-import com.ferreusveritas.dynamictrees.data.provider.DTBlockTagsProvider;
-import com.ferreusveritas.dynamictrees.data.provider.DTItemTagsProvider;
-import com.ferreusveritas.dynamictrees.resources.DTResourceRegistries;
 import com.ferreusveritas.dynamictrees.trees.Family;
 import com.ferreusveritas.dynamictrees.trees.Species;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.color.BlockColors;
-import net.minecraft.data.BlockTagsProvider;
-import net.minecraft.data.ItemTagsProvider;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.GatherDataEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -52,7 +41,6 @@ public class DynamicTreesBOP
 //    }
 
     public void gatherData(final GatherDataEvent event) {
-        DTResourceRegistries.TREES_RESOURCE_MANAGER.gatherData();
         GatherDataHelper.gatherAllData(
                 MOD_ID,
                 event,

--- a/src/main/java/therealeststu/dtbop/cells/DTBOPCellKits.java
+++ b/src/main/java/therealeststu/dtbop/cells/DTBOPCellKits.java
@@ -1,10 +1,10 @@
 package therealeststu.dtbop.cells;
 
+import com.ferreusveritas.dynamictrees.api.cells.Cell;
 import com.ferreusveritas.dynamictrees.api.cells.CellKit;
 import com.ferreusveritas.dynamictrees.api.cells.CellNull;
-import com.ferreusveritas.dynamictrees.api.cells.ICell;
-import com.ferreusveritas.dynamictrees.api.cells.ICellSolver;
-import com.ferreusveritas.dynamictrees.api.registry.IRegistry;
+import com.ferreusveritas.dynamictrees.api.cells.CellSolver;
+import com.ferreusveritas.dynamictrees.api.registry.Registry;
 import com.ferreusveritas.dynamictrees.cells.*;
 import com.ferreusveritas.dynamictrees.util.SimpleVoxmap;
 import net.minecraft.util.Direction;
@@ -15,22 +15,22 @@ import therealeststu.dtbop.cells.cell.*;
 public class DTBOPCellKits {
 
     public static class SparseCellKit extends CellKit{
-        protected final ICell sparseBranch = new SparseBranchCell();
-        protected final ICell sparseLeaves = new NormalCell(1);
+        protected final Cell sparseBranch = new SparseBranchCell();
+        protected final Cell sparseLeaves = new NormalCell(1);
 
-        protected final ICellSolver solver = new com.ferreusveritas.dynamictrees.cells.CellKits.BasicSolver(new short[] {0x0211});
+        protected final CellSolver solver = new com.ferreusveritas.dynamictrees.cells.CellKits.BasicSolver(new short[] {0x0211});
 
         public SparseCellKit(ResourceLocation registryName) {
             super(registryName);
         }
 
         @Override
-        public ICell getCellForLeaves(int hydro) {
+        public Cell getCellForLeaves(int hydro) {
             return hydro > 0 ? sparseLeaves : CellNull.NULL_CELL;
         }
 
         @Override
-        public ICell getCellForBranch(int radius, int meta) {
+        public Cell getCellForBranch(int radius, int meta) {
             return radius == 1 ? sparseBranch : CellNull.NULL_CELL;
         }
 
@@ -40,7 +40,7 @@ public class DTBOPCellKits {
         }
 
         @Override
-        public ICellSolver getCellSolver() {
+        public CellSolver getCellSolver() {
             return solver;
         }
 
@@ -52,18 +52,18 @@ public class DTBOPCellKits {
 
     public static final CellKit SPARSE = new SparseCellKit(new ResourceLocation(DynamicTreesBOP.MOD_ID, "sparse"));
     public static final CellKit HELLBARK_SPARSE = new SparseCellKit(new ResourceLocation(DynamicTreesBOP.MOD_ID, "hellbark_sparse")) {
-        @Override public ICell getCellForBranch(int radius, int meta) {
+        @Override public Cell getCellForBranch(int radius, int meta) {
             return radius <= 3 ? sparseBranch : CellNull.NULL_CELL;
         }
     };
 
     public static final CellKit POPLAR = new CellKit(new ResourceLocation(DynamicTreesBOP.MOD_ID, "poplar")) {
 
-        private final ICell poplarBranch = new PoplarBranchCell();
-        private final ICell poplarTopBranch = new PoplarTopBranchCell();
-        private final ICell poplarUpperTrunk = new NormalCell(4);
+        private final Cell poplarBranch = new PoplarBranchCell();
+        private final Cell poplarTopBranch = new PoplarTopBranchCell();
+        private final Cell poplarUpperTrunk = new NormalCell(4);
 
-        private final ICell[] poplarLeaves = new ICell[] {
+        private final Cell[] poplarLeaves = new Cell[] {
                 CellNull.NULL_CELL,
                 new PoplarLeafCell(1),
                 new PoplarLeafCell(2),
@@ -71,17 +71,17 @@ public class DTBOPCellKits {
                 new PoplarLeafCell(4),
         };
 
-        private final ICellSolver solver = new CellKits.BasicSolver(new short[] {
+        private final CellSolver solver = new CellKits.BasicSolver(new short[] {
                 0x0412, 0x0311, 0x0211
         });
 
         @Override
-        public ICell getCellForLeaves(int hydro) {
+        public Cell getCellForLeaves(int hydro) {
             return poplarLeaves[hydro];
         }
 
         @Override
-        public ICell getCellForBranch(int radius, int meta) {
+        public Cell getCellForBranch(int radius, int meta) {
             if (meta == MetadataCell.CONIFERTOP) return poplarTopBranch;
             if (radius == 1) return poplarBranch;
             if (radius < 4) return poplarUpperTrunk;
@@ -94,7 +94,7 @@ public class DTBOPCellKits {
         }
 
         @Override
-        public ICellSolver getCellSolver() {
+        public CellSolver getCellSolver() {
             return solver;
         }
 
@@ -107,9 +107,9 @@ public class DTBOPCellKits {
 
     public static final CellKit MAHOGANY = new CellKit(new ResourceLocation(DynamicTreesBOP.MOD_ID, "mahogany")) {
 
-        private final ICell mahoganyBranch = new MahoganyBranchCell();
+        private final Cell mahoganyBranch = new MahoganyBranchCell();
 
-        private final ICell[] mahoganyLeafCells = {
+        private final Cell[] mahoganyLeafCells = {
                 CellNull.NULL_CELL,
                 new MahoganyLeafCell(1),
                 new MahoganyLeafCell(2),
@@ -117,17 +117,17 @@ public class DTBOPCellKits {
                 new MahoganyLeafCell(4)
         };
 
-        private final ICellSolver solver = new com.ferreusveritas.dynamictrees.cells.CellKits.BasicSolver(new short[] {
+        private final CellSolver solver = new com.ferreusveritas.dynamictrees.cells.CellKits.BasicSolver(new short[] {
                 0x0513, 0x0413, 0x0322, 0x0311, 0x0211
         });
 
         @Override
-        public ICell getCellForLeaves(int hydro) {
+        public Cell getCellForLeaves(int hydro) {
             return mahoganyLeafCells[hydro];
         }
 
         @Override
-        public ICell getCellForBranch(int radius, int meta) {
+        public Cell getCellForBranch(int radius, int meta) {
             if (radius == 1) return mahoganyBranch;
             return CellNull.NULL_CELL;
         }
@@ -138,7 +138,7 @@ public class DTBOPCellKits {
         }
 
         @Override
-        public ICellSolver getCellSolver() {
+        public CellSolver getCellSolver() {
             return solver;
         }
 
@@ -151,13 +151,13 @@ public class DTBOPCellKits {
 
     public static final CellKit BRUSH = new CellKit(new ResourceLocation(DynamicTreesBOP.MOD_ID, "brush")) {
 
-        private final ICell branch = new ICell() {
+        private final Cell branch = new Cell() {
             @Override public int getValue() { return 5; }
             final int[] map = {3, 3, 5, 5, 5, 5};
             @Override public int getValueFromSide(Direction side) { return map[side.ordinal()]; }
         };
 
-        private final ICell[] normalCells = {
+        private final Cell[] normalCells = {
                 CellNull.NULL_CELL,
                 new NormalCell(1),
                 new NormalCell(2),
@@ -165,17 +165,17 @@ public class DTBOPCellKits {
                 new NormalCell(4),
         };
 
-        private final ICellSolver solver = new com.ferreusveritas.dynamictrees.cells.CellKits.BasicSolver(new short[] {
+        private final CellSolver solver = new com.ferreusveritas.dynamictrees.cells.CellKits.BasicSolver(new short[] {
                 0x0513, 0x0412, 0x0322, 0x0311, 0x0211,
         });
 
         @Override
-        public ICell getCellForLeaves(int hydro) {
+        public Cell getCellForLeaves(int hydro) {
             return normalCells[hydro];
         }
 
         @Override
-        public ICell getCellForBranch(int radius, int meta) {
+        public Cell getCellForBranch(int radius, int meta) {
             if (radius == 1) return branch;
             return CellNull.NULL_CELL;
         }
@@ -186,7 +186,7 @@ public class DTBOPCellKits {
         }
 
         @Override
-        public ICellSolver getCellSolver() {
+        public CellSolver getCellSolver() {
             return solver;
         }
 
@@ -199,11 +199,11 @@ public class DTBOPCellKits {
 
     public static final CellKit EUCALYPTUS = new CellKit(new ResourceLocation(DynamicTreesBOP.MOD_ID, "eucalyptus")) {
 
-        private final ICell eucalyptusTopBranch = new EucalyptusTopBranchCell();
-        private final ICell eucalyptusBranch = new NormalCell(2);
-        private final ICell eucalyptusUpperTrunk = new NormalCell(3);
+        private final Cell eucalyptusTopBranch = new EucalyptusTopBranchCell();
+        private final Cell eucalyptusBranch = new NormalCell(2);
+        private final Cell eucalyptusUpperTrunk = new NormalCell(3);
 
-        private final ICell[] eucalyptusLeaves = new ICell[] {
+        private final Cell[] eucalyptusLeaves = new Cell[] {
                 CellNull.NULL_CELL,
                 new EucalyptusLeafCell(1),
                 new EucalyptusLeafCell(2),
@@ -211,17 +211,17 @@ public class DTBOPCellKits {
                 new EucalyptusLeafCell(4),
         };
 
-        private final ICellSolver solver = new com.ferreusveritas.dynamictrees.cells.CellKits.BasicSolver(new short[] {
+        private final CellSolver solver = new com.ferreusveritas.dynamictrees.cells.CellKits.BasicSolver(new short[] {
                 0x0514, 0x0423, 0x0411, 0x0312, 0x0211
         });
 
         @Override
-        public ICell getCellForLeaves(int hydro) {
+        public Cell getCellForLeaves(int hydro) {
             return eucalyptusLeaves[hydro];
         }
 
         @Override
-        public ICell getCellForBranch(int radius, int meta) {
+        public Cell getCellForBranch(int radius, int meta) {
             if (meta == MetadataCell.CONIFERTOP) return eucalyptusTopBranch;
             if (radius == 1) return eucalyptusBranch;
             if (radius <= 3) return eucalyptusUpperTrunk;
@@ -234,7 +234,7 @@ public class DTBOPCellKits {
         }
 
         @Override
-        public ICellSolver getCellSolver() {
+        public CellSolver getCellSolver() {
             return solver;
         }
 
@@ -247,7 +247,7 @@ public class DTBOPCellKits {
 
     public static final CellKit HELLBARK = new CellKit(new ResourceLocation(DynamicTreesBOP.MOD_ID, "hellbark")) {
 
-        private final ICell hellbarkBranch = new ICell() {
+        private final Cell hellbarkBranch = new Cell() {
             @Override
             public int getValue() {
                 return 5;
@@ -262,7 +262,7 @@ public class DTBOPCellKits {
 
         };
 
-        private final ICell[] hellbarkLeafCells = {
+        private final Cell[] hellbarkLeafCells = {
                 CellNull.NULL_CELL,
                 new HellbarkLeafCell(1),
                 new HellbarkLeafCell(2),
@@ -276,12 +276,12 @@ public class DTBOPCellKits {
         private final CellKits.BasicSolver hellbarkSolver = new CellKits.BasicSolver(new short[]{0x0716,0x0615, 0x0514, 0x0423, 0x0312, 0x0221});
 
         @Override
-        public ICell getCellForLeaves(int hydro) {
+        public Cell getCellForLeaves(int hydro) {
             return hellbarkLeafCells[hydro];
         }
 
         @Override
-        public ICell getCellForBranch(int radius, int meta) {
+        public Cell getCellForBranch(int radius, int meta) {
             return radius <= 4 ? hellbarkBranch : CellNull.NULL_CELL;
         }
 
@@ -291,7 +291,7 @@ public class DTBOPCellKits {
         }
 
         @Override
-        public ICellSolver getCellSolver() {
+        public CellSolver getCellSolver() {
             return hellbarkSolver;
         }
 
@@ -302,7 +302,7 @@ public class DTBOPCellKits {
 
     };
 
-    public static void register(final IRegistry<CellKit> registry) {
+    public static void register(final Registry<CellKit> registry) {
         registry.registerAll(SPARSE, POPLAR, MAHOGANY, BRUSH, EUCALYPTUS, HELLBARK, HELLBARK_SPARSE);
     }
 

--- a/src/main/java/therealeststu/dtbop/cells/cell/EucalyptusTopBranchCell.java
+++ b/src/main/java/therealeststu/dtbop/cells/cell/EucalyptusTopBranchCell.java
@@ -1,9 +1,9 @@
 package therealeststu.dtbop.cells.cell;
 
-import com.ferreusveritas.dynamictrees.api.cells.ICell;
+import com.ferreusveritas.dynamictrees.api.cells.Cell;
 import net.minecraft.util.Direction;
 
-public class EucalyptusTopBranchCell implements ICell {
+public class EucalyptusTopBranchCell implements Cell {
 
     @Override
     public int getValue() {

--- a/src/main/java/therealeststu/dtbop/cells/cell/MahoganyBranchCell.java
+++ b/src/main/java/therealeststu/dtbop/cells/cell/MahoganyBranchCell.java
@@ -1,9 +1,9 @@
 package therealeststu.dtbop.cells.cell;
 
-import com.ferreusveritas.dynamictrees.api.cells.ICell;
+import com.ferreusveritas.dynamictrees.api.cells.Cell;
 import net.minecraft.util.Direction;
 
-public class MahoganyBranchCell implements ICell {
+public class MahoganyBranchCell implements Cell {
 
     @Override
     public int getValue() {

--- a/src/main/java/therealeststu/dtbop/cells/cell/PoplarBranchCell.java
+++ b/src/main/java/therealeststu/dtbop/cells/cell/PoplarBranchCell.java
@@ -1,9 +1,9 @@
 package therealeststu.dtbop.cells.cell;
 
-import com.ferreusveritas.dynamictrees.api.cells.ICell;
+import com.ferreusveritas.dynamictrees.api.cells.Cell;
 import net.minecraft.util.Direction;
 
-public class PoplarBranchCell implements ICell {
+public class PoplarBranchCell implements Cell {
 	
 	@Override
 	public int getValue() {

--- a/src/main/java/therealeststu/dtbop/cells/cell/PoplarTopBranchCell.java
+++ b/src/main/java/therealeststu/dtbop/cells/cell/PoplarTopBranchCell.java
@@ -1,9 +1,9 @@
 package therealeststu.dtbop.cells.cell;
 
-import com.ferreusveritas.dynamictrees.api.cells.ICell;
+import com.ferreusveritas.dynamictrees.api.cells.Cell;
 import net.minecraft.util.Direction;
 
-public class PoplarTopBranchCell implements ICell {
+public class PoplarTopBranchCell implements Cell {
 
 	@Override
 	public int getValue() {

--- a/src/main/java/therealeststu/dtbop/cells/cell/SparseBranchCell.java
+++ b/src/main/java/therealeststu/dtbop/cells/cell/SparseBranchCell.java
@@ -1,9 +1,9 @@
 package therealeststu.dtbop.cells.cell;
 
-import com.ferreusveritas.dynamictrees.api.cells.ICell;
+import com.ferreusveritas.dynamictrees.api.cells.Cell;
 import net.minecraft.util.Direction;
 
-public class SparseBranchCell implements ICell {
+public class SparseBranchCell implements Cell {
 
 	@Override
 	public int getValue() {

--- a/src/main/java/therealeststu/dtbop/dropcreators/DTBOPDropCreators.java
+++ b/src/main/java/therealeststu/dtbop/dropcreators/DTBOPDropCreators.java
@@ -1,6 +1,6 @@
 package therealeststu.dtbop.dropcreators;
 
-import com.ferreusveritas.dynamictrees.api.registry.IRegistry;
+import com.ferreusveritas.dynamictrees.api.registry.Registry;
 import com.ferreusveritas.dynamictrees.systems.dropcreators.DropCreator;
 import net.minecraft.util.ResourceLocation;
 import therealeststu.dtbop.DynamicTreesBOP;
@@ -9,7 +9,7 @@ public class DTBOPDropCreators {
 
     public static final DropCreator LEAVES_STRING = new StringDropCreator(new ResourceLocation(DynamicTreesBOP.MOD_ID, "leaves_string"));
 
-    public static void register(final IRegistry<DropCreator> registry) {
+    public static void register(final Registry<DropCreator> registry) {
         registry.registerAll(LEAVES_STRING);
     }
 

--- a/src/main/java/therealeststu/dtbop/dropcreators/StringDropCreator.java
+++ b/src/main/java/therealeststu/dtbop/dropcreators/StringDropCreator.java
@@ -1,17 +1,11 @@
 package therealeststu.dtbop.dropcreators;
 
-import com.ferreusveritas.dynamictrees.systems.dropcreators.ConfiguredDropCreator;
 import com.ferreusveritas.dynamictrees.systems.dropcreators.DropCreator;
+import com.ferreusveritas.dynamictrees.systems.dropcreators.DropCreatorConfiguration;
 import com.ferreusveritas.dynamictrees.systems.dropcreators.context.DropContext;
-import com.ferreusveritas.dynamictrees.trees.Species;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
-
-import java.util.List;
-import java.util.Random;
 
 public class StringDropCreator extends DropCreator {
 
@@ -20,7 +14,7 @@ public class StringDropCreator extends DropCreator {
     }
 
     @Override
-    protected ConfiguredDropCreator<DropCreator> createDefaultConfiguration() {
+    protected DropCreatorConfiguration createDefaultConfiguration() {
         return super.createDefaultConfiguration().with(RARITY, 1f);
     }
 
@@ -30,7 +24,7 @@ public class StringDropCreator extends DropCreator {
     }
 
     @Override
-    public void appendHarvestDrops(ConfiguredDropCreator<DropCreator> configuration, DropContext context) {
+    public void appendHarvestDrops(DropCreatorConfiguration configuration, DropContext context) {
         int chance = (int) (10 * configuration.get(RARITY));
         if (context.fortune() > 0) {
             chance -= 2 << context.fortune();
@@ -46,7 +40,7 @@ public class StringDropCreator extends DropCreator {
     }
 
     @Override
-    public void appendLeavesDrops(ConfiguredDropCreator<DropCreator> configuration, DropContext context) {
+    public void appendLeavesDrops(DropCreatorConfiguration configuration, DropContext context) {
         if (context.world().getRandom().nextFloat() < configuration.get(RARITY))
             context.drops().add(new ItemStack(Items.STRING));
     }

--- a/src/main/java/therealeststu/dtbop/genfeature/AlternativeLeavesGenFeature.java
+++ b/src/main/java/therealeststu/dtbop/genfeature/AlternativeLeavesGenFeature.java
@@ -1,13 +1,13 @@
 package therealeststu.dtbop.genfeature;
 
-import com.ferreusveritas.dynamictrees.api.IPostGenFeature;
-import com.ferreusveritas.dynamictrees.api.IPostGrowFeature;
 import com.ferreusveritas.dynamictrees.api.TreeHelper;
 import com.ferreusveritas.dynamictrees.api.configurations.ConfigurationProperty;
 import com.ferreusveritas.dynamictrees.api.network.MapSignal;
 import com.ferreusveritas.dynamictrees.blocks.leaves.DynamicLeavesBlock;
 import com.ferreusveritas.dynamictrees.systems.genfeatures.GenFeature;
-import com.ferreusveritas.dynamictrees.systems.genfeatures.config.ConfiguredGenFeature;
+import com.ferreusveritas.dynamictrees.systems.genfeatures.GenFeatureConfiguration;
+import com.ferreusveritas.dynamictrees.systems.genfeatures.context.PostGenerationContext;
+import com.ferreusveritas.dynamictrees.systems.genfeatures.context.PostGrowContext;
 import com.ferreusveritas.dynamictrees.systems.nodemappers.FindEndsNode;
 import com.ferreusveritas.dynamictrees.trees.Species;
 import com.ferreusveritas.dynamictrees.util.BlockBounds;
@@ -20,13 +20,12 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
-import net.minecraft.world.biome.Biome;
 
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class AlternativeLeavesGenFeature extends GenFeature implements IPostGrowFeature, IPostGenFeature {
+public class AlternativeLeavesGenFeature extends GenFeature {
 
     public static final ConfigurationProperty<Block> ALT_LEAVES = ConfigurationProperty.block("alternative_leaves");
 
@@ -39,70 +38,94 @@ public class AlternativeLeavesGenFeature extends GenFeature implements IPostGrow
         this.register(ALT_LEAVES, PLACE_CHANCE, QUANTITY);
     }
 
-    public ConfiguredGenFeature<GenFeature> createDefaultConfiguration() {
-        return super.createDefaultConfiguration().with(ALT_LEAVES, Blocks.AIR)
-                .with(PLACE_CHANCE, 0.5f).with(QUANTITY, 5);
+    public GenFeatureConfiguration createDefaultConfiguration() {
+        return super.createDefaultConfiguration()
+                .with(ALT_LEAVES, Blocks.AIR)
+                .with(PLACE_CHANCE, 0.5f)
+                .with(QUANTITY, 5);
     }
 
     @Override
-    public boolean postGeneration(ConfiguredGenFeature<?> configuredGenFeature, IWorld world, BlockPos rootPos, Species species, Biome biome, int radius, List<BlockPos> endPoints, SafeChunkBounds safeBounds, BlockState initialDirtState, Float seasonValue, Float seasonFruitProductionFactor) {
-        BlockBounds bounds = species.getFamily().expandLeavesBlockBounds(new BlockBounds(endPoints));
+    protected boolean postGenerate(GenFeatureConfiguration configuration, PostGenerationContext context) {
+        BlockBounds bounds =
+                context.species().getFamily().expandLeavesBlockBounds(new BlockBounds(context.endPoints()));
 
-        return setAltLeaves(configuredGenFeature, world, bounds, safeBounds, species);
+        return setAltLeaves(configuration, context.world(), bounds, context.bounds(), context.species());
     }
 
     @Override
-    public boolean postGrow(ConfiguredGenFeature<?> configuredGenFeature, World world, BlockPos rootPos, BlockPos treePos, Species species, int fertility, boolean natural) {
-        if (fertility == 0) return false;
+    protected boolean postGrow(GenFeatureConfiguration configuration, PostGrowContext context) {
+        if (context.fertility() == 0) {
+            return false;
+        }
+
+        final World world = context.world();
+        final BlockPos rootPos = context.pos();
+        final Species species = context.species();
 
         FindEndsNode endFinder = new FindEndsNode();
         TreeHelper.startAnalysisFromRoot(world, rootPos, new MapSignal(endFinder));
         List<BlockPos> endPoints = endFinder.getEnds();
-        if (endPoints.isEmpty()) return false;
+        if (endPoints.isEmpty()) {
+            return false;
+        }
         BlockPos chosenEndPoint = endPoints.get(world.getRandom().nextInt(endPoints.size()));
         BlockBounds bounds = species.getFamily().expandLeavesBlockBounds(new BlockBounds(chosenEndPoint));
 
-        return setAltLeaves(configuredGenFeature, world, bounds, SafeChunkBounds.ANY, species);
+        return setAltLeaves(configuration, world, bounds, SafeChunkBounds.ANY, species);
     }
 
-    private BlockState getSwapBlockState (ConfiguredGenFeature<?> configuredGenFeature, IWorld world, Species species, BlockState state, boolean worldgen){
-        DynamicLeavesBlock originalLeaves = species.getLeavesBlock().orElse(null);
-        Block alt = configuredGenFeature.get(ALT_LEAVES);
-        DynamicLeavesBlock altLeaves = alt instanceof DynamicLeavesBlock ? (DynamicLeavesBlock) alt : null;
-        if (originalLeaves != null && altLeaves != null){
-            if (worldgen || world.getRandom().nextFloat() < configuredGenFeature.get(PLACE_CHANCE)){
-                if (state.getBlock() == originalLeaves)
-                    return altLeaves.properties.getDynamicLeavesState(state.getValue(LeavesBlock.DISTANCE));
-            } else {
-                if (state.getBlock() == altLeaves)
-                    return originalLeaves.properties.getDynamicLeavesState(state.getValue(LeavesBlock.DISTANCE));
-            }
-        }
-        return state;
-    }
-
-    private boolean setAltLeaves (ConfiguredGenFeature<?> configuredGenFeature, IWorld world, BlockBounds leafPositions, SafeChunkBounds safeBounds, Species species){
+    private boolean setAltLeaves(GenFeatureConfiguration configuration, IWorld world, BlockBounds leafPositions,
+                                 SafeChunkBounds safeBounds, Species species) {
         boolean worldGen = safeBounds != SafeChunkBounds.ANY;
 
-        if (worldGen){
+        if (worldGen) {
             AtomicBoolean isSet = new AtomicBoolean(false);
-            leafPositions.iterator().forEachRemaining((pos)->{
-                if (safeBounds.inBounds(pos, true) && world.getRandom().nextFloat() < configuredGenFeature.get(PLACE_CHANCE))
-                    if (world.setBlock(pos, getSwapBlockState(configuredGenFeature, world, species, world.getBlockState(pos), true), 2))
+            leafPositions.iterator().forEachRemaining((pos) -> {
+                if (safeBounds.inBounds(pos, true) && world.getRandom().nextFloat() < configuration.get(PLACE_CHANCE)) {
+                    if (world.setBlock(pos,
+                            getSwapBlockState(configuration, world, species, world.getBlockState(pos), true), 2)) {
                         isSet.set(true);
+                    }
+                }
             });
             return isSet.get();
         } else {
             boolean isSet = false;
             List<BlockPos> posList = new LinkedList<>();
-            for (BlockPos leafPosition : leafPositions) posList.add(new BlockPos(leafPosition));
-            if (posList.isEmpty()) return false;
-            for (int i=0; i<configuredGenFeature.get(QUANTITY); i++){
+            for (BlockPos leafPosition : leafPositions) {
+                posList.add(new BlockPos(leafPosition));
+            }
+            if (posList.isEmpty()) {
+                return false;
+            }
+            for (int i = 0; i < configuration.get(QUANTITY); i++) {
                 BlockPos pos = posList.get(world.getRandom().nextInt(posList.size()));
-                if (world.setBlock(pos, getSwapBlockState(configuredGenFeature, world, species, world.getBlockState(pos), false), 2))
+                if (world.setBlock(pos,
+                        getSwapBlockState(configuration, world, species, world.getBlockState(pos), false), 2)) {
                     isSet = true;
+                }
             }
             return isSet;
         }
+    }
+
+    private BlockState getSwapBlockState(GenFeatureConfiguration configuration, IWorld world, Species species,
+                                         BlockState state, boolean worldgen) {
+        DynamicLeavesBlock originalLeaves = species.getLeavesBlock().orElse(null);
+        Block alt = configuration.get(ALT_LEAVES);
+        DynamicLeavesBlock altLeaves = alt instanceof DynamicLeavesBlock ? (DynamicLeavesBlock) alt : null;
+        if (originalLeaves != null && altLeaves != null) {
+            if (worldgen || world.getRandom().nextFloat() < configuration.get(PLACE_CHANCE)) {
+                if (state.getBlock() == originalLeaves) {
+                    return altLeaves.properties.getDynamicLeavesState(state.getValue(LeavesBlock.DISTANCE));
+                }
+            } else {
+                if (state.getBlock() == altLeaves) {
+                    return originalLeaves.properties.getDynamicLeavesState(state.getValue(LeavesBlock.DISTANCE));
+                }
+            }
+        }
+        return state;
     }
 }

--- a/src/main/java/therealeststu/dtbop/genfeature/DTBOPGenFeatures.java
+++ b/src/main/java/therealeststu/dtbop/genfeature/DTBOPGenFeatures.java
@@ -1,27 +1,16 @@
 package therealeststu.dtbop.genfeature;
 
-import com.ferreusveritas.dynamictrees.api.registry.IRegistry;
+import com.ferreusveritas.dynamictrees.api.registry.Registry;
 import com.ferreusveritas.dynamictrees.systems.genfeatures.GenFeature;
-import com.ferreusveritas.dynamictrees.systems.genfeatures.VinesGenFeature;
-import com.ferreusveritas.dynamictrees.systems.genfeatures.config.ConfiguredGenFeature;
-import com.ferreusveritas.dynamictrees.trees.Species;
-import com.ferreusveritas.dynamictrees.util.SafeChunkBounds;
-import net.minecraft.block.BlockState;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.IWorld;
-import net.minecraft.world.biome.Biome;
 import therealeststu.dtbop.DynamicTreesBOP;
-
-import java.util.List;
-import java.util.Objects;
 
 public class DTBOPGenFeatures {
 
     public static final GenFeature ALT_LEAVES = new AlternativeLeavesGenFeature(new ResourceLocation(DynamicTreesBOP.MOD_ID, "alt_leaves"));
     public static final GenFeature EXTRA_FLARE_BOTTOM = new ExtraBottomFlareGenFeature(new ResourceLocation(DynamicTreesBOP.MOD_ID, "extra_bottom_flare"));
 
-    public static void register(final IRegistry<GenFeature> registry) {
+    public static void register(final Registry<GenFeature> registry) {
         registry.registerAll(ALT_LEAVES, EXTRA_FLARE_BOTTOM);
     }
 

--- a/src/main/java/therealeststu/dtbop/genfeature/ExtraBottomFlareGenFeature.java
+++ b/src/main/java/therealeststu/dtbop/genfeature/ExtraBottomFlareGenFeature.java
@@ -1,25 +1,18 @@
 package therealeststu.dtbop.genfeature;
 
-import com.ferreusveritas.dynamictrees.api.IPostGenFeature;
-import com.ferreusveritas.dynamictrees.api.IPostGrowFeature;
 import com.ferreusveritas.dynamictrees.api.TreeHelper;
 import com.ferreusveritas.dynamictrees.api.configurations.ConfigurationProperty;
 import com.ferreusveritas.dynamictrees.systems.genfeatures.GenFeature;
-import com.ferreusveritas.dynamictrees.systems.genfeatures.config.ConfiguredGenFeature;
-import com.ferreusveritas.dynamictrees.trees.Family;
+import com.ferreusveritas.dynamictrees.systems.genfeatures.GenFeatureConfiguration;
+import com.ferreusveritas.dynamictrees.systems.genfeatures.context.PostGenerationContext;
+import com.ferreusveritas.dynamictrees.systems.genfeatures.context.PostGrowContext;
 import com.ferreusveritas.dynamictrees.trees.Species;
-import com.ferreusveritas.dynamictrees.util.SafeChunkBounds;
-import net.minecraft.block.BlockState;
 import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IWorld;
-import net.minecraft.world.World;
-import net.minecraft.world.biome.Biome;
 
-import java.util.List;
-
-public class ExtraBottomFlareGenFeature extends GenFeature implements IPostGenFeature, IPostGrowFeature{
+public class ExtraBottomFlareGenFeature extends GenFeature {
 
 	// Min radius for the flare.
 	public static final ConfigurationProperty<Integer> MIN_RADIUS = ConfigurationProperty.integer("min_radius");
@@ -38,46 +31,46 @@ public class ExtraBottomFlareGenFeature extends GenFeature implements IPostGenFe
 	}
 
 	@Override
-	public ConfiguredGenFeature<GenFeature> createDefaultConfiguration() {
+	public GenFeatureConfiguration createDefaultConfiguration() {
 		return super.createDefaultConfiguration().with(MIN_RADIUS, 6).with(SECONDARY_MIN_RADIUS, 8);
 	}
 
 	@Override
-	public boolean postGrow(ConfiguredGenFeature<?> configuredGenFeature, World world, BlockPos rootPos, BlockPos treePos, Species species, int fertility, boolean natural) {
-		if(fertility > 0) {
-			this.flareBottom(configuredGenFeature, world, rootPos, species);
+	protected boolean postGrow(GenFeatureConfiguration configuration, PostGrowContext context) {
+		if (context.fertility() > 0) {
+			this.flareBottom(configuration, context.world(), context.pos(), context.species());
 			return true;
 		}
 		return false;
 	}
 
 	@Override
-	public boolean postGeneration(ConfiguredGenFeature<?> configuredGenFeature, IWorld world, BlockPos rootPos, Species species, Biome biome, int radius, List<BlockPos> endPoints, SafeChunkBounds safeBounds, BlockState initialDirtState, Float seasonValue, Float seasonFruitProductionFactor) {
-		this.flareBottom(configuredGenFeature, world, rootPos, species);
+	protected boolean postGenerate(GenFeatureConfiguration configuration, PostGenerationContext context) {
+		this.flareBottom(configuration, context.world(), context.pos(), context.species());
 		return true;
 	}
-	
+
 	/**
 	 * Put a cute little flare on the bottom of the dark oaks
 	 * 
 	 * @param world The world
 	 * @param rootPos The position of the rooty dirt block of the tree
 	 */
-	public void flareBottom(ConfiguredGenFeature<?> configuredGenFeature, IWorld world, BlockPos rootPos, Species species) {
-		Family family = species.getFamily();
-
-		int radius4 = TreeHelper.getRadius(world, rootPos.above(4));
-		if (radius4 > configuredGenFeature.get(SECONDARY_MIN_RADIUS)) {
-			family.getBranch().setRadius(world, rootPos.above(3), radius4 + 1, Direction.UP);
-			family.getBranch().setRadius(world, rootPos.above(2), radius4 + 3, Direction.UP);
-			family.getBranch().setRadius(world, rootPos.above(1), radius4 + 6, Direction.UP);
-		} else {
-			int radius3 = TreeHelper.getRadius(world, rootPos.above(3));
-			if (radius3 > configuredGenFeature.get(MIN_RADIUS)) {
-				family.getBranch().setRadius(world, rootPos.above(2), radius3 + 1, Direction.UP);
-				family.getBranch().setRadius(world, rootPos.above(1), radius3 + 2, Direction.UP);
-			}
-		}
+	public void flareBottom(GenFeatureConfiguration configuredGenFeature, IWorld world, BlockPos rootPos, Species species) {
+		species.getFamily().getBranch().ifPresent(branch -> {
+			int radius4 = TreeHelper.getRadius(world, rootPos.above(4));
+			if (radius4 > configuredGenFeature.get(SECONDARY_MIN_RADIUS)) {
+				branch.setRadius(world, rootPos.above(3), radius4 + 1, Direction.UP);
+				branch.setRadius(world, rootPos.above(2), radius4 + 3, Direction.UP);
+				branch.setRadius(world, rootPos.above(1), radius4 + 6, Direction.UP);
+			} else {
+				int radius3 = TreeHelper.getRadius(world, rootPos.above(3));
+				if (radius3 > configuredGenFeature.get(MIN_RADIUS)) {
+					branch.setRadius(world, rootPos.above(2), radius3 + 1, Direction.UP);
+					branch.setRadius(world, rootPos.above(1), radius3 + 2, Direction.UP);
+				}
+			}	
+		});
 	}
 	
 }

--- a/src/main/java/therealeststu/dtbop/growthlogic/CypressLogic.java
+++ b/src/main/java/therealeststu/dtbop/growthlogic/CypressLogic.java
@@ -2,13 +2,12 @@ package therealeststu.dtbop.growthlogic;
 
 import com.ferreusveritas.dynamictrees.api.TreeHelper;
 import com.ferreusveritas.dynamictrees.growthlogic.GrowthLogicKit;
+import com.ferreusveritas.dynamictrees.growthlogic.GrowthLogicKitConfiguration;
+import com.ferreusveritas.dynamictrees.growthlogic.context.DirectionManipulationContext;
+import com.ferreusveritas.dynamictrees.growthlogic.context.PositionalSpeciesContext;
 import com.ferreusveritas.dynamictrees.systems.GrowSignal;
 import com.ferreusveritas.dynamictrees.trees.Species;
 import com.ferreusveritas.dynamictrees.util.CoordUtils;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
-import net.minecraft.block.NoteBlock;
-import net.minecraft.state.properties.NoteBlockInstrument;
 import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
@@ -21,14 +20,18 @@ public class CypressLogic extends GrowthLogicKit {
     }
 
     @Override
-    public int[] directionManipulation(World world, BlockPos pos, Species species, int radius, GrowSignal signal, int[] probMap) {
-        if (signal.isInTrunk()){
+    public int[] populateDirectionProbabilityMap(GrowthLogicKitConfiguration configuration,
+                                                 DirectionManipulationContext context) {
+        final GrowSignal signal = context.signal();
+        final int[] probMap = context.probMap();
+
+        if (signal.isInTrunk()) {
             int sideProb = 2;
             Direction branchSide = null;
-            if (signal.energy >= 6){
-                if (signal.numSteps % 3 == 0){
-                    for (Direction dir : CoordUtils.HORIZONTALS){
-                        if (TreeHelper.isBranch(world.getBlockState(pos.offset(dir.getNormal())))){
+            if (signal.energy >= 6) {
+                if (signal.numSteps % 3 == 0) {
+                    for (Direction dir : CoordUtils.HORIZONTALS) {
+                        if (TreeHelper.isBranch(context.world().getBlockState(context.pos().offset(dir.getNormal())))) {
                             sideProb = 0;
                             branchSide = dir;
                         }
@@ -38,7 +41,9 @@ public class CypressLogic extends GrowthLogicKit {
                 }
             }
             probMap[2] = probMap[3] = probMap[4] = probMap[5] = sideProb;
-            if (branchSide != null) probMap[branchSide.ordinal()] = 2;
+            if (branchSide != null) {
+                probMap[branchSide.ordinal()] = 2;
+            }
         }
 
         probMap[0] = 0; //disable down
@@ -47,24 +52,27 @@ public class CypressLogic extends GrowthLogicKit {
     }
 
     @Override
-    public Direction newDirectionSelected(Species species, Direction direction, GrowSignal growSignal) {
-        return direction;
+    public float getEnergy(GrowthLogicKitConfiguration configuration, PositionalSpeciesContext context) {
+        final World world = context.world();
+        final BlockPos rootPos = context.pos();
+        final Species species = context.species();
+        return species.getSignalEnergy() +
+                getLowestBranchHeight(configuration, context) * (1.5f +
+                        (getHashedVariation(world, rootPos, 10) /
+                                20)); // Vary the energy between 1.5 and 2.0 times the minimum branch height
     }
 
-    private float getHashedVariation (World world, BlockPos pos, int mod){
+    @Override
+    public int getLowestBranchHeight(GrowthLogicKitConfiguration configuration, PositionalSpeciesContext context) {
+        return (int) (super.getLowestBranchHeight(configuration, context) +
+                getHashedVariation(context.world(), context.pos(),
+                        9)); // Vary the minimum branch height by a psuedorandom hash function
+    }
+
+    private float getHashedVariation(World world, BlockPos pos, int mod) {
         long day = world.getGameTime() / 24000L;
-        int month = (int)day / 30;//Change the hashs every in-game month
-        return (CoordUtils.coordHashCode(pos.above(month), 2) % mod);//Vary the height energy by a psuedorandom hash function
-    }
-
-    @Override
-    public float getEnergy(World world, BlockPos rootPos, Species species, float signalEnergy) {
-        return signalEnergy + getLowestBranchHeight(world, rootPos, species, species.getLowestBranchHeight()) * (1.5f + (getHashedVariation(world, rootPos, 10) / 20)); // Vary the energy between 1.5 and 2.0 times the minimum branch height
-
-    }
-
-    @Override
-    public int getLowestBranchHeight(World world, BlockPos pos, Species species, int lowestBranchHeight) {
-        return (int) (lowestBranchHeight + getHashedVariation(world, pos, 9)); // Vary the minimum branch height by a psuedorandom hash function
+        int month = (int) day / 30;//Change the hashs every in-game month
+        return (CoordUtils.coordHashCode(pos.above(month), 2) %
+                mod);//Vary the height energy by a psuedorandom hash function
     }
 }

--- a/src/main/java/therealeststu/dtbop/growthlogic/DTBOPGrowthLogicKits.java
+++ b/src/main/java/therealeststu/dtbop/growthlogic/DTBOPGrowthLogicKits.java
@@ -1,24 +1,20 @@
 package therealeststu.dtbop.growthlogic;
 
-import com.ferreusveritas.dynamictrees.api.registry.IRegistry;
-import com.ferreusveritas.dynamictrees.growthlogic.ConiferLogic;
+import com.ferreusveritas.dynamictrees.api.registry.Registry;
 import com.ferreusveritas.dynamictrees.growthlogic.GrowthLogicKit;
 import net.minecraft.util.ResourceLocation;
 import therealeststu.dtbop.DynamicTreesBOP;
 
 public class DTBOPGrowthLogicKits {
 
-    public static final GrowthLogicKit POPLAR = new PoplarLogic(new ResourceLocation(DynamicTreesBOP.MOD_ID, "poplar"), false);
-    public static final GrowthLogicKit LARGE_POPLAR = new PoplarLogic(new ResourceLocation(DynamicTreesBOP.MOD_ID, "large_poplar"), true);
+    public static final GrowthLogicKit POPLAR = new PoplarLogic(new ResourceLocation(DynamicTreesBOP.MOD_ID, "poplar"));
     public static final GrowthLogicKit CYPRESS = new CypressLogic(new ResourceLocation(DynamicTreesBOP.MOD_ID, "cypress"));
-    public static final GrowthLogicKit FIR = new ConiferLogic(new ResourceLocation(DynamicTreesBOP.MOD_ID, "fir"),4.5f).setHeightVariation(8);
-    public static final GrowthLogicKit SMALL_CONIFER = new ConiferLogic(new ResourceLocation(DynamicTreesBOP.MOD_ID, "small_conifer"),4.0f);
     public static final GrowthLogicKit REDWOOD = new RedwoodLogic(new ResourceLocation(DynamicTreesBOP.MOD_ID, "redwood"));
     public static final GrowthLogicKit SMALL_REDWOOD = new SmallRedwoodLogic(new ResourceLocation(DynamicTreesBOP.MOD_ID, "small_redwood"));
     public static final GrowthLogicKit MAHOGANY = new MahoganyLogic(new ResourceLocation(DynamicTreesBOP.MOD_ID, "mahogany"));
 
-    public static void register(final IRegistry<GrowthLogicKit> registry) {
-        registry.registerAll(POPLAR, LARGE_POPLAR, CYPRESS, FIR, SMALL_CONIFER, REDWOOD, SMALL_REDWOOD, MAHOGANY);
+    public static void register(final Registry<GrowthLogicKit> registry) {
+        registry.registerAll(POPLAR, CYPRESS, REDWOOD, SMALL_REDWOOD, MAHOGANY);
     }
 
 }

--- a/src/main/java/therealeststu/dtbop/growthlogic/MahoganyLogic.java
+++ b/src/main/java/therealeststu/dtbop/growthlogic/MahoganyLogic.java
@@ -1,20 +1,23 @@
 package therealeststu.dtbop.growthlogic;
 
 import com.ferreusveritas.dynamictrees.growthlogic.GrowthLogicKit;
+import com.ferreusveritas.dynamictrees.growthlogic.GrowthLogicKitConfiguration;
+import com.ferreusveritas.dynamictrees.growthlogic.context.DirectionManipulationContext;
+import com.ferreusveritas.dynamictrees.growthlogic.context.DirectionSelectionContext;
 import com.ferreusveritas.dynamictrees.systems.GrowSignal;
-import com.ferreusveritas.dynamictrees.trees.Species;
 import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 
 public class MahoganyLogic extends GrowthLogicKit {
 
     public MahoganyLogic(ResourceLocation registryName) { super(registryName); }
 
     @Override
-    public int[] directionManipulation(World world, BlockPos pos, Species species, int radius, GrowSignal signal, int[] probMap) {
-        Direction originDir = signal.dir.getOpposite();
+    public int[] populateDirectionProbabilityMap(GrowthLogicKitConfiguration configuration,
+                                                 DirectionManipulationContext context) {
+        final GrowSignal signal = context.signal();
+        final int[] probMap = context.probMap();
+        final Direction originDir = signal.dir.getOpposite();
 
         probMap[0] = 0; // Down is always disallowed for mahogany
 
@@ -40,7 +43,9 @@ public class MahoganyLogic extends GrowthLogicKit {
     }
 
     @Override
-    public Direction newDirectionSelected(Species species, Direction direction, GrowSignal signal) {
+    public Direction selectNewDirection(GrowthLogicKitConfiguration configuration, DirectionSelectionContext context) {
+        final Direction direction = super.selectNewDirection(configuration, context);
+        final GrowSignal signal = context.signal();
         if (direction != Direction.UP) {
             signal.energy += 0.75f;
         }
@@ -50,13 +55,4 @@ public class MahoganyLogic extends GrowthLogicKit {
         return direction;
     }
 
-    @Override
-    public float getEnergy(World world, BlockPos rootPos, Species species, float signalEnergy) {
-        return signalEnergy;
-    }
-
-    @Override
-    public int getLowestBranchHeight(World world, BlockPos pos, Species species, int lowestBranchHeight) {
-        return lowestBranchHeight;
-    }
 }

--- a/src/main/java/therealeststu/dtbop/growthlogic/PoplarLogic.java
+++ b/src/main/java/therealeststu/dtbop/growthlogic/PoplarLogic.java
@@ -1,13 +1,13 @@
 package therealeststu.dtbop.growthlogic;
 
+import com.ferreusveritas.dynamictrees.api.configurations.ConfigurationProperty;
 import com.ferreusveritas.dynamictrees.growthlogic.GrowthLogicKit;
+import com.ferreusveritas.dynamictrees.growthlogic.GrowthLogicKitConfiguration;
+import com.ferreusveritas.dynamictrees.growthlogic.context.DirectionManipulationContext;
+import com.ferreusveritas.dynamictrees.growthlogic.context.DirectionSelectionContext;
+import com.ferreusveritas.dynamictrees.growthlogic.context.PositionalSpeciesContext;
 import com.ferreusveritas.dynamictrees.systems.GrowSignal;
-import com.ferreusveritas.dynamictrees.trees.Species;
 import com.ferreusveritas.dynamictrees.util.CoordUtils;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
-import net.minecraft.block.NoteBlock;
-import net.minecraft.state.properties.NoteBlockInstrument;
 import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
@@ -15,55 +15,79 @@ import net.minecraft.world.World;
 
 public class PoplarLogic extends GrowthLogicKit {
 
-    private final boolean isLarge;
-    public PoplarLogic(ResourceLocation registryName, boolean isLarge) {
+    public static final ConfigurationProperty<Boolean> LARGE = ConfigurationProperty.bool("large");
+
+    public PoplarLogic(ResourceLocation registryName) {
         super(registryName);
-        this.isLarge = isLarge;
     }
 
     @Override
-    public int[] directionManipulation(World world, BlockPos pos, Species species, int radius, GrowSignal signal, int[] probMap) {
-        Direction originDir = signal.dir.getOpposite();
+    protected GrowthLogicKitConfiguration createDefaultConfiguration() {
+        return super.createDefaultConfiguration()
+                .with(LARGE, false);
+    }
+
+    @Override
+    protected void registerProperties() {
+        this.register(LARGE);
+    }
+
+    @Override
+    public int[] populateDirectionProbabilityMap(GrowthLogicKitConfiguration configuration,
+                                                 DirectionManipulationContext context) {
+        final GrowSignal signal = context.signal();
+        final int[] probMap = context.probMap();
+        final Direction originDir = signal.dir.getOpposite();
 
         // Alter probability map for direction change
         probMap[0] = signal.isInTrunk() ? 0 : 1;
-        probMap[1] = signal.isInTrunk() ? species.getUpProbability() : 1;
-        probMap[2] = probMap[3] = probMap[4] = probMap[5] = (((signal.isInTrunk() && signal.numSteps % 2 == 0) || !signal.isInTrunk())) ? 2 : 0; // && signal.energy < species.getSignalEnergy() * 0.8
+        probMap[1] = signal.isInTrunk() ? context.species().getUpProbability() : 1;
+        probMap[2] = probMap[3] = probMap[4] = probMap[5] =
+                (((signal.isInTrunk() && signal.numSteps % 2 == 0) || !signal.isInTrunk())) ? 2 :
+                        0; // && signal.energy < species.getSignalEnergy() * 0.8
         probMap[originDir.ordinal()] = 0; // Disable the direction we came from
-        probMap[signal.dir.ordinal()] += (signal.isInTrunk() ? 0 : signal.numTurns == 1 ? 2 : 1); // Favor current travel direction
+        probMap[signal.dir.ordinal()] +=
+                (signal.isInTrunk() ? 0 : signal.numTurns == 1 ? 2 : 1); // Favor current travel direction
 
         return probMap;
     }
 
     @Override
-    public Direction newDirectionSelected(Species species, Direction newDir, GrowSignal signal) {
-        if (signal.isInTrunk() && newDir != Direction.UP) { // Turned out of trunk
-            if (isLarge && signal.energy >= 12f)
+    public Direction selectNewDirection(GrowthLogicKitConfiguration configuration, DirectionSelectionContext context) {
+        final Direction direction = super.selectNewDirection(configuration, context);
+        final GrowSignal signal = context.signal();
+        final boolean large = configuration.get(LARGE);
+        if (signal.isInTrunk() && direction != Direction.UP) { // Turned out of trunk
+            if (large && signal.energy >= 12f) {
                 signal.energy = 1.8f;
-            else if (isLarge && signal.energy >= 7f)
+            } else if (large && signal.energy >= 7f) {
                 signal.energy = 2.8f;
-            else if (signal.energy >= 4f)
+            } else if (signal.energy >= 4f) {
                 signal.energy = 1.8f; // don't grow branches more than 1 block out from the trunk
-            else
+            } else {
                 signal.energy = 0.8f; // don't grow branches, only leaves
+            }
         }
-        return newDir;
+        return direction;
     }
 
+    @Override
+    public float getEnergy(GrowthLogicKitConfiguration configuration, PositionalSpeciesContext context) {
+        // Vary the height energy by a psuedorandom hash function
+        return context.species().getSignalEnergy() +
+                getHashedVariation(context.world(), context.pos(), 3);
+    }
 
-    private float getHashedVariation (World world, BlockPos pos, int mod){
+    @Override
+    public int getLowestBranchHeight(GrowthLogicKitConfiguration configuration, PositionalSpeciesContext context) {
+        return (int) (super.getLowestBranchHeight(configuration, context) +
+                getHashedVariation(context.world(), context.pos(), 3));
+    }
+
+    private float getHashedVariation(World world, BlockPos pos, int mod) {
         long day = world.getGameTime() / 24000L;
-        int month = (int)day / 30;//Change the hashs every in-game month
-        return (CoordUtils.coordHashCode(pos.above(month), 2) % mod);//Vary the height energy by a psuedorandom hash function
-    }
-
-    @Override
-    public float getEnergy(World world, BlockPos pos, Species species, float signalEnergy) {
-        return signalEnergy + getHashedVariation(world, pos, 3); // Vary the height energy by a psuedorandom hash function
-    }
-
-    @Override
-    public int getLowestBranchHeight(World world, BlockPos pos, Species species, int lowestBranchHeight) {
-        return (int) (lowestBranchHeight + getHashedVariation(world, pos, 3));
+        int month = (int) day / 30;//Change the hashs every in-game month
+        return (CoordUtils.coordHashCode(pos.above(month), 2) %
+                mod);//Vary the height energy by a psuedorandom hash function
     }
 }

--- a/src/main/java/therealeststu/dtbop/growthlogic/RedwoodLogic.java
+++ b/src/main/java/therealeststu/dtbop/growthlogic/RedwoodLogic.java
@@ -1,9 +1,12 @@
 package therealeststu.dtbop.growthlogic;
 
 import com.ferreusveritas.dynamictrees.api.TreeHelper;
-import com.ferreusveritas.dynamictrees.api.treedata.ITreePart;
-import com.ferreusveritas.dynamictrees.blocks.branches.BranchBlock;
+import com.ferreusveritas.dynamictrees.api.treedata.TreePart;
 import com.ferreusveritas.dynamictrees.growthlogic.GrowthLogicKit;
+import com.ferreusveritas.dynamictrees.growthlogic.GrowthLogicKitConfiguration;
+import com.ferreusveritas.dynamictrees.growthlogic.context.DirectionManipulationContext;
+import com.ferreusveritas.dynamictrees.growthlogic.context.DirectionSelectionContext;
+import com.ferreusveritas.dynamictrees.growthlogic.context.PositionalSpeciesContext;
 import com.ferreusveritas.dynamictrees.systems.GrowSignal;
 import com.ferreusveritas.dynamictrees.trees.Species;
 import com.ferreusveritas.dynamictrees.util.CoordUtils;
@@ -20,107 +23,143 @@ public class RedwoodLogic extends GrowthLogicKit {
         super(registryName);
     }
 
-    private int getHashedVariation (World world, BlockPos pos, int readyMade){
-        long day = world.getGameTime() / 24000L;
-        int month = (int)day / 30;//Change the hashs every in-game month
-        return CoordUtils.coordHashCode(pos.above(month), readyMade);
-    }
-    private float getHashedVariation (World world, BlockPos pos, int readyMade, Integer mod){
-        return (getHashedVariation(world, pos, readyMade) % mod);//Vary the height energy by a psuedorandom hash function
-    }
-
     @Override
-    public Direction selectNewDirection(World world, BlockPos pos, Species species, BranchBlock branch, GrowSignal signal) {
-        Direction originDir = signal.dir.getOpposite();
-        int signalY = signal.delta.getY();
+    public Direction selectNewDirection(GrowthLogicKitConfiguration configuration, DirectionSelectionContext context) {
+        final World world = context.world();
+        final BlockPos pos = context.pos();
+        final Species species = context.species();
+        final GrowSignal signal = context.signal();
+        final Direction originDir = signal.dir.getOpposite();
+        final int signalY = signal.delta.getY();
 
         // prevent branches on the ground
-        if(signal.numSteps + 1 <= species.getLowestBranchHeight(world, signal.rootPos)) {
+        if (signal.numSteps + 1 <= configuration.getLowestBranchHeight(context)) {
             return Direction.UP;
         }
 
         int[] probMap = new int[6]; // 6 directions possible DUNSWE
 
         // Probability taking direction into account
-        probMap[Direction.UP.ordinal()] = signal.dir != Direction.DOWN ? species.getUpProbability(): 0; // Favor up
-        probMap[signal.dir.ordinal()] += species.getReinfTravel(); // Favor current direction
+        probMap[Direction.UP.ordinal()] = signal.dir != Direction.DOWN ? species.getUpProbability() : 0; // Favor up
+        probMap[signal.dir.ordinal()] += species.getProbabilityForCurrentDir(); // Favor current direction
 
-        int radius = branch.getRadius(world.getBlockState(pos));
+        int radius = context.branch().getRadius(world.getBlockState(pos));
 
-        if (signal.delta.getY() < species.getLowestBranchHeight(world, pos) - 3) {
+        if (signal.delta.getY() < configuration.getLowestBranchHeight(context) - 3) {
 
             int treeHash = getHashedVariation(world, signal.rootPos, 2);
             int posHash = getHashedVariation(world, pos, 2);
 
             int hashMod = signalY < 7 ? 3 : 11;
-            boolean sideTurn = !signal.isInTrunk() || (signal.isInTrunk() && ((signal.numSteps + treeHash) % hashMod == 0) && (radius > 1)); // Only allow turns when we aren't in the trunk(or the branch is not a twig)
+            boolean sideTurn = !signal.isInTrunk() ||
+                    (signal.isInTrunk() && ((signal.numSteps + treeHash) % hashMod == 0) &&
+                            (radius > 1)); // Only allow turns when we aren't in the trunk(or the branch is not a twig)
 
-            if (!sideTurn) return Direction.UP;
+            if (!sideTurn) {
+                return Direction.UP;
+            }
 
             probMap[2 + (posHash % 4)] = 1;
         }
 
         // Create probability map for direction change
-        for (Direction dir: Direction.values()) {
+        for (Direction dir : Direction.values()) {
             if (!dir.equals(originDir)) {
                 BlockPos deltaPos = pos.offset(dir.getNormal());
                 // Check probability for surrounding blocks
                 // Typically Air:1, Leaves:2, Branches: 2+r
-                if (signalY >= species.getLowestBranchHeight(world, pos)) {
+                if (signalY >= configuration.getLowestBranchHeight(context)) {
                     BlockState deltaBlockState = world.getBlockState(deltaPos);
-                    ITreePart treePart = TreeHelper.getTreePart(deltaBlockState);
+                    TreePart treePart = TreeHelper.getTreePart(deltaBlockState);
 
-                    probMap[dir.ordinal()] += treePart.probabilityForBlock(deltaBlockState, world, deltaPos, branch);
+                    probMap[dir.ordinal()] +=
+                            treePart.probabilityForBlock(deltaBlockState, world, deltaPos, context.branch());
                 }
             }
         }
 
         //Do custom stuff or override probability map for various species
-        probMap = directionManipulation(world, pos, species, radius, signal, probMap);
+        probMap = configuration.populateDirectionProbabilityMap(
+                new DirectionManipulationContext(context.world(), context.pos(), context.species(), context.branch(),
+                        context.signal(), context.branch().getRadius(context.world().getBlockState(context.pos())),
+                        probMap)
+        );
 
         //Select a direction from the probability map
-        int choice = MathHelper.selectRandomFromDistribution(signal.rand, probMap); // Select a direction from the probability map.
-        return newDirectionSelected(species, Direction.values()[choice != -1 ? choice : 1], signal); // Default to up if things are screwy
+        int choice = MathHelper.selectRandomFromDistribution(signal.rand,
+                probMap); // Select a direction from the probability map.
+        return newDirectionSelected(configuration, context,
+                Direction.values()[choice != -1 ? choice : 1]); // Default to up if things are screwy
     }
 
-    @Override
-    public int[] directionManipulation(World world, BlockPos pos, Species species, int radius, GrowSignal signal, int[] probMap) {
-        Direction originDir = signal.dir.getOpposite();
-
-        // Alter probability map for direction change
-        probMap[0] = 0; // Down is always disallowed
-        probMap[1] = signal.isInTrunk() || signal.delta.getY() >= species.getLowestBranchHeight(world, pos) ? species.getUpProbability() : 1;
-        probMap[originDir.ordinal()] = 0; // Disable the direction we came from
-
-        if(signal.numTurns == 1 && signal.delta.distSqr(0, signal.delta.getY(), 0, true) == 1.0 ) {
-            probMap[1] = 0; //disable up if we JUST turned out of the trunk, this is to prevent branches from interfering at the tip
-        }
-
-        return probMap;
-    }
-
-    @Override
-    public Direction newDirectionSelected(Species species, Direction newDir, GrowSignal signal) {
+    private Direction newDirectionSelected(GrowthLogicKitConfiguration configuration,
+                                           DirectionSelectionContext context,
+                                           Direction newDir) {
+        final GrowSignal signal = context.signal();
         if (signal.isInTrunk() && newDir != Direction.UP) { // Turned out of trunk
             int signalY = signal.delta.getY();
-            if (signalY < species.getLowestBranchHeight()) {
-                signal.energy = 0.9f + ((1f - ((float) signalY / species.getLowestBranchHeight())) * 3.7f);
+            if (signalY < configuration.getLowestBranchHeight(context)) {
+                signal.energy = 0.9f + ((1f - ((float) signalY / configuration.getLowestBranchHeight(context))) * 3.7f);
             } else {
                 signal.energy += 5;
                 signal.energy /= 4.8f;
-                if (signal.energy > 5.8f) signal.energy = 5.8f;
+                if (signal.energy > 5.8f) {
+                    signal.energy = 5.8f;
+                }
             }
         }
         return newDir;
     }
 
     @Override
-    public float getEnergy(World world, BlockPos pos, Species species, float signalEnergy) {
-        return signalEnergy * species.biomeSuitability(world, pos) + getHashedVariation(world, pos,2, 16); // Vary the height energy by a psuedorandom hash function
+    public int[] populateDirectionProbabilityMap(GrowthLogicKitConfiguration configuration,
+                                                 DirectionManipulationContext context) {
+        final GrowSignal signal = context.signal();
+        final int[] probMap = context.probMap();
+        final Direction originDir = signal.dir.getOpposite();
+
+        // Alter probability map for direction change
+        probMap[0] = 0; // Down is always disallowed
+        probMap[1] = signal.isInTrunk() || signal.delta.getY() >= configuration.getLowestBranchHeight(context) ?
+                context.species().getUpProbability() : 1;
+        probMap[originDir.ordinal()] = 0; // Disable the direction we came from
+
+        if (signal.numTurns == 1 && signal.delta.distSqr(0, signal.delta.getY(), 0, true) == 1.0) {
+            probMap[1] =
+                    0; //disable up if we JUST turned out of the trunk, this is to prevent branches from interfering at the tip
+        }
+
+        return probMap;
     }
 
     @Override
-    public int getLowestBranchHeight(World world, BlockPos pos, Species species, int lowestBranchHeight) {
-        return (int) ((lowestBranchHeight + getHashedVariation(world, pos,2, 16) * 0.5f) * species.biomeSuitability(world, pos)) ;
+    public float getEnergy(GrowthLogicKitConfiguration configuration, PositionalSpeciesContext context) {
+        final World world = context.world();
+        final BlockPos pos = context.pos();
+        final Species species = context.species();
+        // Vary the height energy by a psuedorandom hash function
+        return species.getSignalEnergy() * species.biomeSuitability(world, pos) +
+                getHashedVariation(world, pos, 2, 16);
     }
+
+    @Override
+    public int getLowestBranchHeight(GrowthLogicKitConfiguration configuration, PositionalSpeciesContext context) {
+        final World world = context.world();
+        final BlockPos pos = context.pos();
+        return (int) ((super.getLowestBranchHeight(configuration, context) +
+                getHashedVariation(world, pos, 2, 16) * 0.5f) *
+                context.species().biomeSuitability(world, pos));
+    }
+
+    private int getHashedVariation(World world, BlockPos pos, int readyMade) {
+        long day = world.getGameTime() / 24000L;
+        int month = (int) day / 30;//Change the hashs every in-game month
+        return CoordUtils.coordHashCode(pos.above(month), readyMade);
+    }
+
+    private float getHashedVariation(World world, BlockPos pos, int readyMade, Integer mod) {
+        return (getHashedVariation(world, pos, readyMade) %
+                mod);//Vary the height energy by a psuedorandom hash function
+    }
+
 }

--- a/src/main/java/therealeststu/dtbop/growthlogic/SmallRedwoodLogic.java
+++ b/src/main/java/therealeststu/dtbop/growthlogic/SmallRedwoodLogic.java
@@ -1,12 +1,9 @@
 package therealeststu.dtbop.growthlogic;
 
 import com.ferreusveritas.dynamictrees.growthlogic.ConiferLogic;
-import com.ferreusveritas.dynamictrees.trees.Species;
+import com.ferreusveritas.dynamictrees.growthlogic.GrowthLogicKitConfiguration;
+import com.ferreusveritas.dynamictrees.growthlogic.context.PositionalSpeciesContext;
 import com.ferreusveritas.dynamictrees.util.CoordUtils;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
-import net.minecraft.block.NoteBlock;
-import net.minecraft.state.properties.NoteBlockInstrument;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -14,23 +11,33 @@ import net.minecraft.world.World;
 public class SmallRedwoodLogic extends ConiferLogic {
 
     public SmallRedwoodLogic(ResourceLocation registryName) {
-        super(registryName, 5.0f);
+        super(registryName);
     }
 
-    private float getHashedVariation (World world, BlockPos pos, int mod){
+    @Override
+    protected GrowthLogicKitConfiguration createDefaultConfiguration() {
+        return super.createDefaultConfiguration()
+                .with(ENERGY_DIVISOR, 5.0F);
+    }
+
+    @Override
+    public float getEnergy(GrowthLogicKitConfiguration configuration, PositionalSpeciesContext context) {
+        return configuration.getLowestBranchHeight(context) + context.species().getSignalEnergy() +
+                getHashedVariation(context.world(), context.pos(), 8);
+    }
+
+    @Override
+    public int getLowestBranchHeight(GrowthLogicKitConfiguration configuration, PositionalSpeciesContext context) {
+        // Vary the minimum branch height by a psuedorandom hash function
+        return (int) (super.getLowestBranchHeight(configuration, context) +
+                getHashedVariation(context.world(), context.pos(), 11));
+    }
+
+    private float getHashedVariation(World world, BlockPos pos, int mod) {
         long day = world.getGameTime() / 24000L;
-        int month = (int)day / 30;//Change the hashs every in-game month
-        return (CoordUtils.coordHashCode(pos.above(month), 2) % mod);//Vary the height energy by a psuedorandom hash function
+        int month = (int) day / 30;//Change the hashs every in-game month
+        return (CoordUtils.coordHashCode(pos.above(month), 2) %
+                mod);//Vary the height energy by a psuedorandom hash function
     }
 
-    @Override
-    public float getEnergy(World world, BlockPos rootPos, Species species, float signalEnergy) {
-        return getLowestBranchHeight(world, rootPos, species, species.getLowestBranchHeight()) + signalEnergy + getHashedVariation(world, rootPos, 8);
-
-    }
-
-    @Override
-    public int getLowestBranchHeight(World world, BlockPos pos, Species species, int lowestBranchHeight) {
-        return (int) (lowestBranchHeight + getHashedVariation(world, pos, 11)); // Vary the minimum branch height by a psuedorandom hash function
-    }
 }

--- a/src/main/java/therealeststu/dtbop/trees/CypressSpecies.java
+++ b/src/main/java/therealeststu/dtbop/trees/CypressSpecies.java
@@ -1,10 +1,8 @@
 package therealeststu.dtbop.trees;
 
 import com.ferreusveritas.dynamictrees.api.registry.TypedRegistry;
-import com.ferreusveritas.dynamictrees.blocks.branches.BranchBlock;
 import com.ferreusveritas.dynamictrees.blocks.leaves.LeavesProperties;
 import com.ferreusveritas.dynamictrees.blocks.rootyblocks.SoilHelper;
-import com.ferreusveritas.dynamictrees.systems.GrowSignal;
 import com.ferreusveritas.dynamictrees.trees.Family;
 import com.ferreusveritas.dynamictrees.trees.Species;
 import com.ferreusveritas.dynamictrees.util.SafeChunkBounds;
@@ -14,7 +12,6 @@ import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IWorld;
-import net.minecraft.world.World;
 
 public class CypressSpecies extends Species {
 
@@ -22,11 +19,6 @@ public class CypressSpecies extends Species {
 
     public CypressSpecies(ResourceLocation name, Family family, LeavesProperties leavesProperties) {
         super(name, family, leavesProperties);
-    }
-
-    @Override
-    public Direction selectNewDirection(World world, BlockPos pos, BranchBlock branch, GrowSignal signal) {
-        return super.selectNewDirection(world, pos, branch, signal);
     }
 
     private static final int maxDepth = 3;

--- a/src/main/java/therealeststu/dtbop/trees/GenOnStoneSpecies.java
+++ b/src/main/java/therealeststu/dtbop/trees/GenOnStoneSpecies.java
@@ -2,7 +2,6 @@ package therealeststu.dtbop.trees;
 
 import com.ferreusveritas.dynamictrees.api.registry.TypedRegistry;
 import com.ferreusveritas.dynamictrees.blocks.leaves.LeavesProperties;
-import com.ferreusveritas.dynamictrees.blocks.rootyblocks.RootyBlock;
 import com.ferreusveritas.dynamictrees.blocks.rootyblocks.SoilHelper;
 import com.ferreusveritas.dynamictrees.trees.Family;
 import com.ferreusveritas.dynamictrees.trees.Species;
@@ -30,9 +29,9 @@ public class GenOnStoneSpecies extends Species {
     @Override
     public boolean placeRootyDirtBlock(IWorld world, BlockPos rootPos, int fertility) {
         if (world.getBlockState(rootPos).is(Blocks.STONE)) {
-            RootyBlock rootyBlock = SoilHelper.getProperties(Blocks.GRAVEL).getDynamicSoilBlock();
-            if (rootyBlock != null)
+            SoilHelper.getProperties(Blocks.GRAVEL).getBlock().ifPresent(rootyBlock -> {
                 world.setBlock(rootPos, rootyBlock.defaultBlockState(), 3);//the super does the rest of setting up the soil
+            });
         }
         return super.placeRootyDirtBlock(world, rootPos, fertility);
     }

--- a/src/main/java/therealeststu/dtbop/trees/PoplarSpecies.java
+++ b/src/main/java/therealeststu/dtbop/trees/PoplarSpecies.java
@@ -1,9 +1,9 @@
 package therealeststu.dtbop.trees;
 
 import com.ferreusveritas.dynamictrees.api.TreeHelper;
-import com.ferreusveritas.dynamictrees.api.network.INodeInspector;
+import com.ferreusveritas.dynamictrees.api.network.NodeInspector;
 import com.ferreusveritas.dynamictrees.api.registry.TypedRegistry;
-import com.ferreusveritas.dynamictrees.api.treedata.ITreePart;
+import com.ferreusveritas.dynamictrees.api.treedata.TreePart;
 import com.ferreusveritas.dynamictrees.blocks.branches.BranchBlock;
 import com.ferreusveritas.dynamictrees.blocks.leaves.LeavesProperties;
 import com.ferreusveritas.dynamictrees.trees.Family;
@@ -25,11 +25,11 @@ public class PoplarSpecies extends Species {
     }
 
     @Override
-    public INodeInspector getNodeInflator(SimpleVoxmap leafMap) {
+    public NodeInspector getNodeInflator(SimpleVoxmap leafMap) {
         return new NodeInflatorPoplar(this, leafMap);
     }
 
-    public class NodeInflatorPoplar implements INodeInspector {
+    public class NodeInflatorPoplar implements NodeInspector {
 
         private float radius;
         private BlockPos last;
@@ -75,7 +75,7 @@ public class PoplarSpecies extends Species {
                         }
 
                         BlockState deltaBlockState = world.getBlockState(dPos);
-                        ITreePart treepart = TreeHelper.getTreePart(deltaBlockState);
+                        TreePart treepart = TreeHelper.getTreePart(deltaBlockState);
                         if (branch.isSameTree(treepart)) {
                             int branchRadius = treepart.getRadius(deltaBlockState);
                             areaAccum += branchRadius * branchRadius;

--- a/src/main/resources/trees/dtbop/growth_logic_kits/configurations/fir.json
+++ b/src/main/resources/trees/dtbop/growth_logic_kits/configurations/fir.json
@@ -1,0 +1,7 @@
+{
+  "name": "conifer",
+  "properties": {
+    "energy_divisor": 4.5,
+    "height_variation": 4.5
+  }
+}

--- a/src/main/resources/trees/dtbop/growth_logic_kits/configurations/small_conifer.json
+++ b/src/main/resources/trees/dtbop/growth_logic_kits/configurations/small_conifer.json
@@ -1,0 +1,6 @@
+{
+  "name": "conifer",
+  "properties": {
+    "energy_divisor": 4
+  }
+}

--- a/src/main/resources/trees/dtbop/species/infested.json
+++ b/src/main/resources/trees/dtbop/species/infested.json
@@ -15,7 +15,7 @@
     {
       "name": "dtbop:alt_leaves",
       "properties": {
-        "alternative_leaves": "dtbop:silk_leaves",
+        "alternative_leaves": "dtbop:silk_web",
         "place_chance": 0.3
       }
     }

--- a/src/main/resources/trees/dtbop/species/large_magic_poplar.json
+++ b/src/main/resources/trees/dtbop/species/large_magic_poplar.json
@@ -6,7 +6,12 @@
   "up_probability": 10,
   "lowest_branch_height": 8,
   "growth_rate": 0.85,
-  "growth_logic_kit": "dtbop:large_poplar",
+  "growth_logic_kit": {
+    "name": "dtbop:poplar",
+    "properties": {
+      "large": true
+    }
+  },
   "leaves_properties": "dtbop:magic_poplar",
   "perfect_biomes": { "name": "biomesoplenty:mystic.*" }
 }

--- a/src/main/resources/trees/dynamictrees/species/dark_oak.json
+++ b/src/main/resources/trees/dynamictrees/species/dark_oak.json
@@ -15,8 +15,6 @@
     "dry": 0.25,
     "mushroom": 1.25
   },
-  "seed_drop_rarity": 1.0,
-  "stick_drop_rarity": 1.0,
   "perfect_biomes": { "type": "spooky", "name": "minecraft:.*" },
   "primitive_sapling": "dark_oak_sapling",
   "features" : [


### PR DESCRIPTION
Changes included in this PR:

- Made necessary changes to work with DT 0.10.0 Beta 27.
- Fixed deprecated use of `stick_drop_rarity` and `leaves_drop_rarity` in dark oak override. 
- Fixed outdated and incorrect reference to silk web (`dtbop:silk_leaves` -> `dtbop:silk_web`). 