### PR TITLE
Fix Flowering Oak leaves not working properly

### DIFF
--- a/src/main/java/dynamictreesbop/trees/species/SpeciesFloweringOak.java
+++ b/src/main/java/dynamictreesbop/trees/species/SpeciesFloweringOak.java
@@ -52,7 +52,7 @@ public class SpeciesFloweringOak extends Species {
 	}
 
 	public SpeciesFloweringOak(TreeFamily treeFamily) {
-		super(new ResourceLocation(DynamicTreesBOP.MODID, ModContent.FLOWERINGOAK), treeFamily, ModContent.floweringOakLeavesProperties[0]);
+		this(new ResourceLocation(DynamicTreesBOP.MODID, ModContent.FLOWERINGOAK), treeFamily, ModContent.floweringOakLeavesProperties[0]);
 
 		addValidLeavesBlocks(ModContent.floweringOakLeavesProperties);
 		ModContent.floweringOakLeavesProperties[0].setTree(treeFamily);


### PR DESCRIPTION
Fixes Flowering Oak trees not working properly with Flowering Oak Leaves.
Fixes #83
Tested using Mixin in heavily modified modpack, Flowering Oak/Flowering Apple/Peach all working with this change.