### PR TITLE
Fixed spruce undergrowth 1.19.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 modName=DynamicTreesBOP
 modId=dtbop
-modVersion=3.1.3
+modVersion=3.1.4
 group=therealeststu.dtbop
 
 mcVersion=1.19.2

--- a/src/main/resources/trees/dtbop/species/spruce_undergrowth.json
+++ b/src/main/resources/trees/dtbop/species/spruce_undergrowth.json
@@ -4,5 +4,6 @@
   "lowest_branch_height": 0,
   "signal_energy": 1.2,
   "soil_longevity": 1,
-  "leaves_properties": "dtbop:acacia_undergrowth"
+  "leaves_properties": "dtbop:spruce_undergrowth",
+  "acceptable_soils": ["dirt_like"]
 }


### PR DESCRIPTION
idk why but debug mode is active by default in 1.19.2