### PR TITLE
Updated dependencies to replace environment_factors.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,93 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "Client",
+      "presentation": {
+        "group": "Mod Development - DynamicTrees-BOP",
+        "order": 0
+      },
+      "projectName": "DynamicTrees-BOP",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@/home/sylvan/repos/DynamicTrees-BOP/build/moddev/clientRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@/home/sylvan/repos/DynamicTrees-BOP/build/moddev/clientRunVmArgs.txt",
+        "-Dfml.modFolders\u003ddtbop%%/home/sylvan/repos/DynamicTrees-BOP/bin/main"
+      ],
+      "cwd": "${workspaceFolder}/run",
+      "env": {},
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "Data",
+      "presentation": {
+        "group": "Mod Development - DynamicTrees-BOP",
+        "order": 1
+      },
+      "projectName": "DynamicTrees-BOP",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@/home/sylvan/repos/DynamicTrees-BOP/build/moddev/dataRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@/home/sylvan/repos/DynamicTrees-BOP/build/moddev/dataRunVmArgs.txt",
+        "-Dfml.modFolders\u003ddtbop%%/home/sylvan/repos/DynamicTrees-BOP/bin/main"
+      ],
+      "cwd": "${workspaceFolder}/run",
+      "env": {},
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "GameTestServer",
+      "presentation": {
+        "group": "Mod Development - DynamicTrees-BOP",
+        "order": 2
+      },
+      "projectName": "DynamicTrees-BOP",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@/home/sylvan/repos/DynamicTrees-BOP/build/moddev/gameTestServerRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@/home/sylvan/repos/DynamicTrees-BOP/build/moddev/gameTestServerRunVmArgs.txt",
+        "-Dfml.modFolders\u003ddtbop%%/home/sylvan/repos/DynamicTrees-BOP/bin/main"
+      ],
+      "cwd": "${workspaceFolder}/run",
+      "env": {},
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "Server",
+      "presentation": {
+        "group": "Mod Development - DynamicTrees-BOP",
+        "order": 3
+      },
+      "projectName": "DynamicTrees-BOP",
+      "mainClass": "net.neoforged.devlaunch.Main",
+      "args": [
+        "@/home/sylvan/repos/DynamicTrees-BOP/build/moddev/serverRunProgramArgs.txt"
+      ],
+      "vmArgs": [
+        "@/home/sylvan/repos/DynamicTrees-BOP/build/moddev/serverRunVmArgs.txt",
+        "-Dfml.modFolders\u003ddtbop%%/home/sylvan/repos/DynamicTrees-BOP/bin/main"
+      ],
+      "cwd": "${workspaceFolder}/run",
+      "env": {},
+      "console": "internalConsole",
+      "shortenCommandLine": "none"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -3,18 +3,81 @@ import me.modmuss50.mpp.ReleaseType
 plugins {
     id 'java-library'
     id 'maven-publish'
-    id 'net.neoforged.moddev' version '2.0.75'
+    id 'net.neoforged.moddev' version '2.0.107'
     id 'idea'
+    id 'eclipse'
     id "me.modmuss50.mod-publish-plugin" version "0.8.4"
+}
+
+tasks.named('wrapper', Wrapper).configure {
+    distributionType = Wrapper.DistributionType.BIN
 }
 
 version = mod_version
 group = mod_group_id
 
 repositories {
-    mavenLocal()
-    maven { url = "https://cursemaven.com" }
-    maven { url = "https://harleyoconnor.com/maven" }
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = "Modrinth"
+                url = "https://api.modrinth.com/maven"
+            }
+        }
+        filter {
+            includeGroup "maven.modrinth"
+        }
+    }
+    maven {
+        name "DynamicTrees maven"
+        url "https://harleyoconnor.com/maven"
+    }
+    maven {
+        name "jTDev MavenReleases"
+        url "https://maven.jt-dev.tech/releases"
+    }
+    maven {
+        url "https://maven.squiddev.cc"
+        content {
+            includeGroup("cc.tweaked")
+        }
+    }
+    maven {
+        name "Jared's maven"
+        url "https://maven.blamejared.com/"
+    }
+    maven {
+        name = "jTDev MavenReleases"
+        url = uri("https://maven.jt-dev.tech/releases")
+    }
+    maven {
+        name "Forge maven" //For Terrablender
+        url "https://maven.minecraftforge.net/"
+    }
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = 'GeckoLib'
+                url = 'https://dl.cloudsmith.io/public/geckolib3/geckolib/maven/'
+            }
+        }
+        filter { 
+            includeGroup('software.bernie.geckolib')
+        }
+    }
+    exclusiveContent {
+        forRepository {
+            maven {
+                url "https://cursemaven.com"
+            }
+        }
+        filter {
+            includeGroup "curse.maven"
+        }
+    }
+    flatDir {
+        dir 'libs'
+    }
 }
 
 base {
@@ -28,8 +91,9 @@ neoForge {
 
     parchment {
         mappingsVersion = project.parchment_mappings_version
-        minecraftVersion = project.minecraft_version
+        minecraftVersion = project.parchment_minecraft_version
     }
+
     runs {
         client {
             client()
@@ -47,47 +111,77 @@ neoForge {
             systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
         }
 
+
         data {
             data()
+
             programArguments.addAll '--mod', project.mod_id, '--all',
                     '--output', file('src/generated/resources/').getAbsolutePath(),
-                    '--existing', file('src/main/resources').getAbsolutePath(),
-                    "--existing-mod", "dynamictrees",
-                    "--existing-mod", "biomesoplenty"
+                    '--existing', file('src/main/resources/').getAbsolutePath(),
+                    '--existing-mod', 'dynamictrees',
+                    '--existing-mod', 'biomeswevegone'
         }
 
-        // applies to all the run configs above
         configureEach {
             systemProperty 'forge.logging.markers', 'REGISTRIES'
-
             logLevel = org.slf4j.event.Level.DEBUG
         }
     }
+
     mods {
         "${mod_id}" {
-            sourceSet sourceSets.main
+            sourceSet(sourceSets.main)
         }
     }
 }
 
 sourceSets.main.resources { srcDir 'src/generated/resources' }
 
+configurations {
+    runtimeClasspath.extendsFrom localRuntime
+}
+
 dependencies {
-    //DynamicTrees
-    implementation "com.dtteam.dynamictrees:dynamictrees-neoforge-" + project.minecraft_version + ":" + project.dynamicTreesVersion
-    implementation "com.dtteam.dynamictreesplus:DynamicTreesPlus:" + project.dynamicTreesPlusVersion
-    //implementation "curse.maven:dynamictrees-252818:6111832"
+    // Dynamic Trees
+    implementation "com.dtteam.dynamictrees:dynamictrees-neoforge-${minecraft_version}:${dynamic_trees_version}"
+    implementation "com.dtteam.dynamictreesplus:DynamicTreesPlus:${dynamic_trees_plus_version}"
 
     //DynmaicTrees Tools/Utilities
-    runtimeOnly "curse.maven:jade-324717:6011258"
-    runtimeOnly "curse.maven:jei-238222:5846880"
-    runtimeOnly "curse.maven:cc-tweaked-282001:5714512"
-    runtimeOnly "curse.maven:suggestion-provider-fix-469647:5598604"
+    runtimeOnly "maven.modrinth:jade:${jade_version}+neoforge"
+    runtimeOnly "mezz.jei:jei-${minecraft_version}-neoforge:${jei_version}"
+    runtimeOnly "cc.tweaked:cc-tweaked-${minecraft_version}-forge:${cc_version}"
+    //runtimeOnly "curse.maven:suggestion-provider-fix-469647:5598604"
 
     //Biomes O Plenty
-    implementation "curse.maven:terrablender-940057:6054947"
-    implementation "curse.maven:biomes-o-plenty-220318:5855568"
-    implementation "curse.maven:glitchcore-955399:5660740"
+    implementation "com.github.glitchfiend:TerraBlender-neoforge:${minecraft_version}-${terrablender_version}"
+    implementation "maven.modrinth:HXF82T3G:${bop_version}"
+    //implementation "curse.maven:glitchcore-955399:5660740"
+}
+
+tasks.withType(ProcessResources).configureEach {
+    var replaceProperties = [
+            minecraft_version           : minecraft_version,
+            minecraft_version_range     : minecraft_version_range,
+            neo_version                 : neo_version,
+            loader_version_range        : loader_version_range,
+            mod_id                      : mod_id,
+            mod_name                    : mod_name,
+            mod_license                 : mod_license,
+            mod_version                 : mod_version,
+            mod_authors                 : mod_authors,
+            mod_credits                 : mod_credits,
+            mod_description             : mod_description,
+            mod_url                     : mod_url,
+            mod_update_url              : mod_update_url,
+            mod_issue_url               : mod_issue_url,
+            dynamic_trees_version       : dynamic_trees_version,
+            dynamic_trees_plus_version  : dynamic_trees_plus_version,
+            bop_version                 : bop_version
+    ]
+    inputs.properties replaceProperties
+    filesMatching(["META-INF/neoforge.mods.toml"]) {
+        expand replaceProperties
+    }
 }
 
 def changelogFile = file("build/changelog.txt")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 mod_name=DynamicTreesBOP
 mod_id=dtbop
-mod_version=3.4.0
+mod_version=3.4.1
 mod_group_id=therealeststu.dtbop
 mod_authors=mangoose, Max Hyper
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,35 @@ mod_name=DynamicTreesBOP
 mod_id=dtbop
 mod_version=3.4.1
 mod_group_id=therealeststu.dtbop
+mod_license=MIT
+mod_credits=mangoose, Max Hyper
 mod_authors=mangoose, Max Hyper
+mod_description=Compatibility Mod between Dynamic trees and Biomes o' plenty
+mod_url=https://www.curseforge.com/minecraft/mc-mods/dtbop
+mod_issue_url=https://github.com/DynamicTreesTeam/DynamicTrees-BOP/issues
+mod_update_url=https://github.com/DynamicTreesTeam/DynamicTreesVersionInfo/blob/master/Add-ons/BOP.json?raw=true
 
-minecraft_version=1.21.1
+parchment_minecraft_version=1.21.1
 parchment_mappings_version=2024.11.17
-neo_version=21.1.97
 
-dynamicTreesVersion=1.5.0
-dynamicTreesPlusVersion=1.3.0-BETA04
+# Environment Properties
+minecraft_version=1.21.1
+minecraft_version_range=[1.21.1]
+neo_version=21.1.208
+loader_version_range=[1,)
+
+# Dynamic Trees
+dynamic_trees_version=1.7.2
+dynamic_trees_plus_version=1.3.2
+
+# Utilities
+jade_version=15.10.5
+jei_version=19.39.0.371
+cc_version=1.120.0
+
+# Addon
+bop_version=BtZKRp69
+terrablender_version=4.1.0.8
 
 versionType=stable
 versionRecommended=true

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,52 +1,50 @@
 modLoader="javafml"
-loaderVersion="[1,)"
-license="MIT"
+loaderVersion="${loader_version_range}"
+license="${mod_license}"
+issueTrackerURL="${mod_issue_url}"
 
-[[mods]] #mandatory
-modId="dtbop" #mandatory
-version="${file.jarVersion}" #mandatory
-displayName="Dynamic Trees for Biomes o' Plenty" #mandatory
-updateJSONURL="https://github.com/DynamicTreesTeam/DynamicTreesVersionInfo/blob/master/Add-ons/BOP.json?raw=true" #optional
-displayURL="https://www.curseforge.com/minecraft/mc-mods/dtbop" #optional
-logoFile="" #optional
-credits="ferreusveritas, Nyfaria, ISNing, Groupix05" #optional
-authors="mangoose, Max Hyper" #optional
+[[mods]]
+modId="${mod_id}"
+version="${mod_version}"
+displayName="${mod_name}"
+updateJSONURL="${mod_update_url}"
+displayURL="${mod_url}"
+logoFile=""
+credits="${mod_credits}"
+authors="${mod_authors}"
+description='''${mod_description}'''
 
-description='''
-Compatibility Mod between Dynamic trees and Biomes o' plenty
-'''
-
-[[dependencies.dtbop]] #optional
+[[dependencies.dtbop]]
     modId="neoforge"
     type="required"
-    versionRange="[21.1.0,)"
+    versionRange="[${neo_version},)"
     ordering="NONE"
     side="BOTH"
 
 [[dependencies.dtbop]]
     modId="minecraft"
     type="required"
-    versionRange="[1.21.1]"
+    versionRange="${minecraft_version_range}"
     ordering="NONE"
     side="BOTH"
 
 [[dependencies.dtbop]]
     modId="dynamictrees"
-    type="required"
-    versionRange="[1.5.0-BETA01,)"
+    type="optional"
+    versionRange="[${dynamic_trees_version},)"
     ordering="AFTER"
     side="BOTH"
 
 [[dependencies.dtbop]]
     modId="dynamictreesplus"
-    type="optional"
-    versionRange="[1.2.0-BETA1,)"
+    type="required"
+    versionRange="[${dynamic_trees_plus_version},)"
     ordering="AFTER"
     side="BOTH"
 
 [[dependencies.dtbop]]
     modId="biomesoplenty"
     type="required"
-    versionRange="[21.1.0.7,)"
+    versionRange="[${bop_version},)"
     ordering="AFTER"
     side="BOTH"

--- a/src/main/resources/trees/dtbop/species/acacia_twiglet.json
+++ b/src/main/resources/trees/dtbop/species/acacia_twiglet.json
@@ -2,10 +2,8 @@
   "type": "dtbop:twiglet",
   "family": "acacia",
   "leaves_properties": "dtbop:acacia_twiglet",
-  "environment_factors" : {
-    "cold": 0.5,
-    "dry": 1.05
-  },
+  "preferred_climate": "arid",
+  "climate_tolerance": 0.4,
   "perfect_biomes": { "name": "biomesoplenty:.*scrublands.*" },
   "acceptable_soils": ["dirt_like", "sand_like"]
 }

--- a/src/main/resources/trees/dtbop/species/alps_spruce.json
+++ b/src/main/resources/trees/dtbop/species/alps_spruce.json
@@ -8,12 +8,9 @@
   "growth_rate": 0.9,
   "growth_logic_kit": "conifer",
   "leaves_properties": "spruce",
-  "environment_factors" : {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
-  "perfect_biomes": { "type": "coniferous" },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
+  "perfect_biomes": { "tag": "#c:is_coniferous" },
   "mega_species": "mega_spruce",
   "acceptable_soils": ["dirt_like", "gravel_like"],
   "features" : [

--- a/src/main/resources/trees/dtbop/species/aspen.json
+++ b/src/main/resources/trees/dtbop/species/aspen.json
@@ -1,22 +1,18 @@
 {
-    "family":"birch",
-    "generate_seed": true,
-    "generate_sapling": true,
-    "tapering": 0.95,
-    "signal_energy": 18.0,
-    "up_probability": 3.2,
-    "lowest_branch_height": 5,
-    "growth_rate": 1.5,
-    "growth_logic_kit": "conifer",
-    "leaves_properties":"dtbop:aspen",
-    "environment_factors": {
-        "#forge:is_hot": 0.50,
-        "#forge:is_dry": 0.25,
-        "#forge:is_wet": 0.75
-    },
-    "perfect_biomes": { "type": "biomesoplenty:aspen_glade" },
-    "primitive_sapling":"biomesoplenty:aspen_sapling",
-    "lang_overrides": {
-        "seed": "Aspen Catkin"
-    }
+  "family": "birch",
+  "generate_seed": true,
+  "generate_sapling": true,
+  "tapering": 0.95,
+  "signal_energy": 18.0,
+  "up_probability": 3.2,
+  "lowest_branch_height": 5,
+  "growth_rate": 1.5,
+  "growth_logic_kit": "conifer",
+  "leaves_properties": "dtbop:aspen",
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
+  "perfect_biomes": { "name": "biomesoplenty:aspen_glade" },
+  "lang_overrides": {
+    "seed": "Aspen Catkin"
+  }
 }

--- a/src/main/resources/trees/dtbop/species/cherry_twiglet.json
+++ b/src/main/resources/trees/dtbop/species/cherry_twiglet.json
@@ -2,10 +2,7 @@
   "type": "dtbop:twiglet",
   "family": "cherry",
   "leaves_properties": "dtbop:cherry_twiglet",
-  "environment_factors" : {
-    "hot": 0.5,
-    "dry": 0.5,
-    "cold": 1.05
-  },
-  "perfect_biomes": { "type": "biomesoplenty:jacaranda_glade" }
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.35,
+  "perfect_biomes": { "name": "biomesoplenty:jacaranda_glade" }
 }

--- a/src/main/resources/trees/dtbop/species/cypress_willow.json
+++ b/src/main/resources/trees/dtbop/species/cypress_willow.json
@@ -10,11 +10,9 @@
   "max_branch_radius": 16,
   "growth_logic_kit": "dtbop:cypress",
   "leaves_properties": "dtbop:cypress_willow",
-  "environment_factors" : {
-    "hot": 0.7,
-    "dry": 0.5
-  },
-  "perfect_biomes": { "types": [ "swamp", "overworld" ] },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.35,
+  "perfect_biomes": { "tags": [ "#c:is_swamp", "#minecraft:is_overworld" ] },
   "acceptable_soils": [ "water_like", "dirt_like", "mud_like" ],
   "features": [
     {

--- a/src/main/resources/trees/dtbop/species/dark_oak_twiglet.json
+++ b/src/main/resources/trees/dtbop/species/dark_oak_twiglet.json
@@ -2,11 +2,8 @@
   "type": "dtbop:twiglet",
   "family": "dark_oak",
   "leaves_properties": "dtbop:dark_oak_twiglet",
-  "environment_factors" : {
-    "dry": 0.5,
-    "cold": 0.7,
-    "wet": 1.05
-  },
-  "perfect_biomes": { "types": ["dead", "swamp"] },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.4,
+  "perfect_biomes": { "tags": ["#c:is_dead", "#c:is_swamp"] },
   "acceptable_soils": ["dirt_like", "sand_like"]
 }

--- a/src/main/resources/trees/dtbop/species/dying.json
+++ b/src/main/resources/trees/dtbop/species/dying.json
@@ -6,12 +6,10 @@
   "signal_energy": 12.0,
   "growth_rate": 0.5,
   "leaves_properties": "dtbop:dying",
-  "environment_factors" : {
-    "lush": 0.75,
-    "spooky": 1.05,
-    "dead": 1.05
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.55,
   "always_show_on_waila": true,
+  "perfect_biomes": { "tags": ["#c:is_dead", "#c:is_spooky"] },
   "primitive_sapling": "biomesoplenty:dead_sapling",
   "acceptable_soils": ["dirt_like", "sand_like"],
   "lang_overrides": {

--- a/src/main/resources/trees/dtbop/species/fir.json
+++ b/src/main/resources/trees/dtbop/species/fir.json
@@ -9,12 +9,9 @@
   "growth_rate": 0.9,
   "growth_logic_kit": "dtbop:small_conifer",
   "leaves_properties": "dtbop:fir",
-  "environment_factors" : {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
-  "perfect_biomes": { "type": "coniferous" },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.25,
+  "perfect_biomes": { "tag": "#c:is_coniferous" },
   "primitive_sapling": "biomesoplenty:fir_sapling",
   "mega_species": "dtbop:mega_fir",
   "features" : [

--- a/src/main/resources/trees/dtbop/species/flowering_apple_oak.json
+++ b/src/main/resources/trees/dtbop/species/flowering_apple_oak.json
@@ -6,11 +6,8 @@
   "lowest_branch_height": 4,
   "growth_rate": 0.7,
   "leaves_properties": "oak",
-  "environment_factors" : {
-    "cold": 0.75,
-    "hot": 0.75,
-    "dry": 0.25
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.3,
   "use_seed_of_other_species": "dynamictrees:apple_oak",
   "perfect_biomes": { "name": "biomesoplenty:orchard" },
   "fruits": [

--- a/src/main/resources/trees/dtbop/species/flowering_oak.json
+++ b/src/main/resources/trees/dtbop/species/flowering_oak.json
@@ -6,13 +6,9 @@
   "signal_energy": 12.0,
   "growth_rate": 0.8,
   "leaves_properties": "oak",
-  "environment_factors" : {
-    "cold": 0.75,
-    "hot": 0.5,
-    "dry": 0.5,
-    "forest": 1.05
-  },
-  "perfect_biomes": { "types": [ "forest", "overworld" ] },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.3,
+  "perfect_biomes": { "tags": [ "#c:is_forest", "#minecraft:is_overworld" ] },
   "primitive_sapling": "biomesoplenty:flowering_oak_sapling",
   "features" : [
     {

--- a/src/main/resources/trees/dtbop/species/hellbark.json
+++ b/src/main/resources/trees/dtbop/species/hellbark.json
@@ -8,10 +8,8 @@
   "lowest_branch_height": 2,
   "soil_longevity": 1,
   "leaves_properties": "dtbop:hellbark",
-  "environment_factors" : {
-    "cold": 0.5,
-    "nether": 1.05
-  },
+  "preferred_climate": "arid",
+  "climate_tolerance": 0.3,
   "always_show_on_waila": false,
   "perfect_biomes": { "type": "nether" },
   "acceptable_soils": [ "nether_like", "dirt_like" ],

--- a/src/main/resources/trees/dtbop/species/hellbark_bush.json
+++ b/src/main/resources/trees/dtbop/species/hellbark_bush.json
@@ -7,10 +7,8 @@
   "lowest_branch_height": 1,
   "growth_rate": 1.0,
   "leaves_properties": "dtbop:hellbark_bush",
-  "environment_factors" : {
-    "cold": 0.5,
-    "nether": 1.05
-  },
+  "preferred_climate": "arid",
+  "climate_tolerance": 0.3,
   "always_show_on_waila": true,
   "generate_seed": false,
   "generate_sapling": false,

--- a/src/main/resources/trees/dtbop/species/infested.json
+++ b/src/main/resources/trees/dtbop/species/infested.json
@@ -4,11 +4,8 @@
   "signal_energy": 12.0,
   "growth_rate": 0.5,
   "leaves_properties": "dtbop:dying",
-  "environment_factors" : {
-    "lush": 0.75,
-    "spooky": 1.05,
-    "dead": 1.05
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.65,
   "primitive_sapling": "biomesoplenty:dead_sapling",
   "perfect_biomes": { "name": "biomesoplenty:silkglade" },
   "features" : [

--- a/src/main/resources/trees/dtbop/species/jacaranda.json
+++ b/src/main/resources/trees/dtbop/species/jacaranda.json
@@ -6,11 +6,9 @@
   "signal_energy": 12.0,
   "growth_rate": 0.9,
   "leaves_properties": "dtbop:jacaranda",
-  "environment_factors" : {
-    "hot": 0.5,
-    "dry": 0.5
-  },
-  "perfect_biomes": { "types": [ "lush", "overworld" ] },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.35,
+  "perfect_biomes": { "tags": [ "#c:is_lush", "#minecraft:is_overworld" ] },
   "primitive_sapling": "biomesoplenty:jacaranda_sapling",
   "features" : [
     "bee_nest"

--- a/src/main/resources/trees/dtbop/species/jungle_twiglet.json
+++ b/src/main/resources/trees/dtbop/species/jungle_twiglet.json
@@ -2,10 +2,7 @@
   "type": "dtbop:twiglet",
   "family": "jungle",
   "leaves_properties": "dtbop:jungle_twiglet",
-  "environment_factors" : {
-    "snowy": 0.25,
-    "hot": 1.05,
-    "dry": 0.75
-  },
+  "preferred_climate": "tropical",
+  "climate_tolerance": 0.35,
   "perfect_biomes": { "name": "biomesoplenty:tropics" }
 }

--- a/src/main/resources/trees/dtbop/species/mahogany.json
+++ b/src/main/resources/trees/dtbop/species/mahogany.json
@@ -9,13 +9,9 @@
   "growth_rate": 0.9,
   "growth_logic_kit": "dtbop:mahogany",
   "leaves_properties": "dtbop:mahogany",
-  "environment_factors" : {
-    "cold": 0.15,
-    "dry": 0.20,
-    "hot": 1.1,
-    "wet": 1.1
-  },
-  "perfect_biomes": { "types": [ "jungle", "overworld" ] },
+  "preferred_climate": "tropical",
+  "climate_tolerance": 0.15,
+  "perfect_biomes": { "tags": [ "#minecraft:is_jungle", "#minecraft:is_overworld" ] },
   "primitive_sapling": "biomesoplenty:mahogany_sapling",
   "lang_overrides": {
     "seed": "Mahogany Pod"

--- a/src/main/resources/trees/dtbop/species/mangrove_twiglet.json
+++ b/src/main/resources/trees/dtbop/species/mangrove_twiglet.json
@@ -2,10 +2,7 @@
   "type": "dtbop:twiglet",
   "family": "mangrove",
   "leaves_properties": "dtbop:mangrove_twiglet",
-  "environment_factors" : {
-    "hot": 0.5,
-    "dry": 0.5,
-    "cold": 1.05
-  },
-  "perfect_biomes": { "type": "biomesoplenty:bog" }
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.4,
+  "perfect_biomes": { "name": "biomesoplenty:bog" }
 }

--- a/src/main/resources/trees/dtbop/species/maple_twiglet.json
+++ b/src/main/resources/trees/dtbop/species/maple_twiglet.json
@@ -2,10 +2,7 @@
   "type": "dtbop:twiglet",
   "family": "dtbop:maple",
   "leaves_properties": "dtbop:maple_twiglet",
-  "environment_factors" : {
-    "hot": 0.5,
-    "dry": 0.5,
-    "cold": 1.05
-  },
-  "perfect_biomes": { "type": "biomesoplenty:tundra.*" }
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.3,
+  "perfect_biomes": { "name": "biomesoplenty:tundra.*" }
 }

--- a/src/main/resources/trees/dtbop/species/mega_dark_oak.json
+++ b/src/main/resources/trees/dtbop/species/mega_dark_oak.json
@@ -8,13 +8,9 @@
   "max_branch_radius": 24,
   "soil_longevity": 45,
   "leaves_properties": "dtbop:mega_dark_oak",
-  "environment_factors" : {
-    "hot": 0.8,
-    "dry": 0.8,
-    "magic": 1.1,
-    "forest": 1.05
-  },
-  "perfect_biomes": { "type": "biomesoplenty:mystic.*" },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.8,
+  "perfect_biomes": { "name": "biomesoplenty:mystic.*" },
   "features" : [
     {
       "name": "rot_soil",

--- a/src/main/resources/trees/dtbop/species/mega_fir.json
+++ b/src/main/resources/trees/dtbop/species/mega_fir.json
@@ -9,12 +9,9 @@
   "max_branch_radius": 24,
   "growth_logic_kit": "dtbop:fir",
   "leaves_properties": "dtbop:fir",
-  "environment_factors" : {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
-  "perfect_biomes": { "type": "coniferous" },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.25,
+  "perfect_biomes": { "tag": "#c:is_coniferous" },
   "common_override": { "name": "biomesoplenty:coniferous_forest" },
   "features" : [
     "conifer_topper",

--- a/src/main/resources/trees/dtbop/species/mega_umbran.json
+++ b/src/main/resources/trees/dtbop/species/mega_umbran.json
@@ -9,16 +9,9 @@
   "max_branch_radius": 24,
   "growth_logic_kit": "dtbop:fir",
   "leaves_properties": "dtbop:umbran",
-  "environment_factors" : {
-    "cold": 0.75,
-    "hot": 0.50,
-    "dry": 0.50,
-    "forest": 1.05,
-    "spooky": 1.1,
-    "dead": 1.1,
-    "magical": 1.1
-  },
-  "perfect_biomes": { "type": "coniferous" },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.7,
+  "perfect_biomes": { "tag": "#c:is_coniferous" },
   "common_override": { "name": "biomesoplenty:ominous_woods" },
   "features" : [
     "conifer_topper",

--- a/src/main/resources/trees/dtbop/species/oak_twiglet.json
+++ b/src/main/resources/trees/dtbop/species/oak_twiglet.json
@@ -2,9 +2,7 @@
   "type": "dtbop:twiglet",
   "family": "oak",
   "leaves_properties": "dtbop:oak_twiglet",
-  "environment_factors" : {
-    "hot": 0.7,
-    "dry": 0.7
-  },
-  "perfect_biomes": { "type": "biomesoplenty:seasonal.*" }
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.45,
+  "perfect_biomes": { "name": "biomesoplenty:seasonal.*" }
 }

--- a/src/main/resources/trees/dtbop/species/orange_maple.json
+++ b/src/main/resources/trees/dtbop/species/orange_maple.json
@@ -8,12 +8,9 @@
   "up_probability": 4,
   "growth_rate": 1.05,
   "leaves_properties": "dtbop:orange_maple",
-  "environment_factors" : {
-    "hot": 0.5,
-    "dry": 0.5,
-    "forest": 1.05
-  },
-  "perfect_biomes": { "type": "biomesoplenty:seasonal.*" },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.35,
+  "perfect_biomes": { "name": "biomesoplenty:seasonal.*" },
   "primitive_sapling": "biomesoplenty:orange_maple_sapling",
   "lang_overrides": {
     "seed": "Orange Maple Samara"

--- a/src/main/resources/trees/dtbop/species/palm.json
+++ b/src/main/resources/trees/dtbop/species/palm.json
@@ -7,11 +7,8 @@
   "signal_energy": 7.0,
   "growth_rate": 0.9,
   "leaves_properties": "dtbop:palm",
-  "environment_factors" : {
-    "cold": 0.75,
-    "hot": 1.1,
-    "dry": 1.1
-  },
+  "preferred_climate": "arid",
+  "climate_tolerance": 0.7,
   "transformable": false,
   "perfect_biomes": { "name": "biomesoplenty:tropics" },
   "primitive_sapling": "biomesoplenty:palm_sapling",

--- a/src/main/resources/trees/dtbop/species/pine.json
+++ b/src/main/resources/trees/dtbop/species/pine.json
@@ -6,11 +6,9 @@
   "signal_energy": 12.0,
   "growth_rate": 0.8,
   "leaves_properties": "dtbop:pine",
-  "environment_factors" : {
-    "wet": 0.75,
-    "plains": 1.05
-  },
-  "perfect_biomes": { "type": "biomesoplenty:hot_springs" },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.5,
+  "perfect_biomes": { "name": "biomesoplenty:hot_springs" },
   "primitive_sapling": "biomesoplenty:pine_sapling",
   "lang_overrides": {
     "seed": "Pine Cone"

--- a/src/main/resources/trees/dtbop/species/rainbow_birch.json
+++ b/src/main/resources/trees/dtbop/species/rainbow_birch.json
@@ -6,12 +6,15 @@
   "signal_energy": 12.0,
   "growth_rate": 0.8,
   "leaves_properties": "dtbop:rainbow_birch",
-  "environment_factors" : {
-    "hot": 0.7,
-    "dry": 0.7,
-    "forest": 1.05
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.45,
+  "perfect_biomes": {
+    "tags": [
+      "#c:is_lush",
+      "#c:is_magical",
+      "#minecraft:is_overworld"
+    ]
   },
-  "perfect_biomes": { "types": [ "lush", "magical", "overworld" ] },
   "primitive_sapling": "biomesoplenty:rainbow_birch_sapling",
   "features" : [
     "bee_nest"

--- a/src/main/resources/trees/dtbop/species/red_maple.json
+++ b/src/main/resources/trees/dtbop/species/red_maple.json
@@ -8,12 +8,9 @@
   "up_probability": 4,
   "growth_rate": 1.05,
   "leaves_properties": "dtbop:red_maple",
-  "environment_factors" : {
-    "hot": 0.5,
-    "dry": 0.5,
-    "forest": 1.05
-  },
-  "perfect_biomes": { "type": "biomesoplenty:seasonal.*" },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.3,
+  "perfect_biomes": { "name": "biomesoplenty:seasonal.*" },
   "primitive_sapling": "biomesoplenty:red_maple_sapling",
   "lang_overrides": {
     "seed": "Red Maple Samara"

--- a/src/main/resources/trees/dtbop/species/redwood.json
+++ b/src/main/resources/trees/dtbop/species/redwood.json
@@ -11,11 +11,8 @@
   "max_branch_radius": 24,
   "growth_logic_kit": "dtbop:redwood",
   "leaves_properties": "dtbop:redwood",
-  "environment_factors" : {
-    "hot": 0.50,
-    "dry": 0.25,
-    "forest": 1.05
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.25,
   "always_show_on_waila": false,
   "world_gen_leaf_map_height": 60,
   "perfect_biomes": { "name": ".*redwood.*" },

--- a/src/main/resources/trees/dtbop/species/short_jungle.json
+++ b/src/main/resources/trees/dtbop/species/short_jungle.json
@@ -7,13 +7,9 @@
   "growth_rate": 0.8,
   "growth_logic_kit": "dtbop:mahogany",
   "leaves_properties": "jungle",
-  "environment_factors" : {
-    "cold": 0.15,
-    "dry": 0.2,
-    "hot": 1.1,
-    "wet": 1.1
-  },
-  "perfect_biomes": { "type": "jungle" },
+  "preferred_climate": "tropical",
+  "climate_tolerance": 0.2,
+  "perfect_biomes": { "tag": "#minecraft:is_jungle" },
   "mega_species": "mega_jungle",
   "features" : [
     {

--- a/src/main/resources/trees/dtbop/species/silk.json
+++ b/src/main/resources/trees/dtbop/species/silk.json
@@ -4,11 +4,15 @@
   "signal_energy": 12.0,
   "growth_rate": 0.5,
   "leaves_properties": "dtbop:silk",
-  "environment_factors" : {
-    "lush": 0.75,
-    "spooky": 1.05,
-    "dead": 1.05
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.55,
   "primitive_sapling": "biomesoplenty:dead_sapling",
-  "perfect_biomes": { "name": "biomesoplenty:silkglade" }
+  "perfect_biomes": {
+    "tags": [
+      "#c:is_lush",
+      "#c:is_spooky",
+      "#c:is_dead"
+    ],
+    "name": "biomesoplenty:silkglade"
+  }
 }

--- a/src/main/resources/trees/dtbop/species/small_redwood.json
+++ b/src/main/resources/trees/dtbop/species/small_redwood.json
@@ -8,11 +8,8 @@
   "soil_longevity": 2,
   "growth_logic_kit": "dtbop:small_redwood",
   "leaves_properties": "dtbop:redwood",
-  "environment_factors" : {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.3,
   "generate_seed": false,
   "generate_sapling": false,
   "perfect_biomes": { "name": ".*redwood.*" },

--- a/src/main/resources/trees/dtbop/species/snowblossom.json
+++ b/src/main/resources/trees/dtbop/species/snowblossom.json
@@ -6,13 +6,15 @@
   "signal_energy": 12.0,
   "growth_rate": 0.8,
   "leaves_properties": "dtbop:snowblossom",
-  "environment_factors" : {
-    "cold": 0.75,
-    "hot": 0.5,
-    "dry": 0.5,
-    "forest": 1.05
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.4,
+  "perfect_biomes": {
+    "tags": [
+      "#c:is_lush",
+      "#minecraft:is_overworld"
+    ],
+    "name": ".*blossom.*"
   },
-  "perfect_biomes": { "types": [ "lush", "overworld" ], "name": ".*blossom.*" },
   "primitive_sapling": "biomesoplenty:snowblossom_sapling",
   "features" : [
     "bee_nest"

--- a/src/main/resources/trees/dtbop/species/snowblossom_twiglet.json
+++ b/src/main/resources/trees/dtbop/species/snowblossom_twiglet.json
@@ -2,10 +2,7 @@
   "type": "dtbop:twiglet",
   "family": "cherry",
   "leaves_properties": "dtbop:snowblossom_twiglet",
-  "environment_factors" : {
-    "hot": 0.5,
-    "dry": 0.5,
-    "cold": 1.05
-  },
-  "perfect_biomes": { "type": "biomesoplenty:jacaranda_glade" }
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.4,
+  "perfect_biomes": { "name": "biomesoplenty:jacaranda_glade" }
 }

--- a/src/main/resources/trees/dtbop/species/sparse_acacia.json
+++ b/src/main/resources/trees/dtbop/species/sparse_acacia.json
@@ -4,11 +4,13 @@
   "signal_energy": 12.0,
   "growth_rate": 0.8,
   "leaves_properties": "dtbop:sparse_acacia",
-  "environment_factors" : {
-    "cold": 0.75,
-    "snowy": 0.5,
-    "dry": 1.05
+  "preferred_climate": "arid",
+  "climate_tolerance": 0.4,
+  "perfect_biomes": {
+    "tags": [
+      "#c:is_desert",
+      "#minecraft:is_overworld"
+    ]
   },
-  "perfect_biomes": { "types": [ "desert", "overworld" ] },
   "acceptable_soils": ["dirt_like", "sand_like"]
 }

--- a/src/main/resources/trees/dtbop/species/sparse_oak.json
+++ b/src/main/resources/trees/dtbop/species/sparse_oak.json
@@ -4,11 +4,14 @@
   "signal_energy": 12.0,
   "growth_rate": 0.8,
   "leaves_properties": "dtbop:sparse_oak",
-  "environment_factors" : {
-    "wet": 0.75,
-    "plains": 1.05
-  },
-  "perfect_biomes": { "types": [ "plains", "overworld" ] },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.45,
+  "perfect_biomes": {
+    "tags": [
+        "#c:is_plains",
+        "#minecraft:is_overworld"
+      ]
+    },
   "features" : [
     {
       "name": "rot_soil",

--- a/src/main/resources/trees/dtbop/species/spruce_twiglet.json
+++ b/src/main/resources/trees/dtbop/species/spruce_twiglet.json
@@ -2,10 +2,7 @@
   "type": "dtbop:twiglet",
   "family": "spruce",
   "leaves_properties": "dtbop:spruce_twiglet",
-  "environment_factors" : {
-    "hot": 0.5,
-    "dry": 0.5,
-    "cold": 1.05
-  },
-  "perfect_biomes": { "type": "biomesoplenty:tundra.*" }
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
+  "perfect_biomes": { "name": "biomesoplenty:tundra.*" }
 }

--- a/src/main/resources/trees/dtbop/species/tall_dying.json
+++ b/src/main/resources/trees/dtbop/species/tall_dying.json
@@ -4,10 +4,15 @@
   "signal_energy": 24.0,
   "growth_rate": 0.5,
   "leaves_properties": "dtbop:dying",
-  "environment_factors" : {
-    "lush": 0.75,
-    "spooky": 1.05,
-    "dead": 1.05
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.55,
+  "perfect_biomes": {
+    "tags": [
+      "biomesoplenty:tundra.*",
+      "#c:is_lush",
+      "#c:is_spooky",
+      "#c:is_dead"
+    ]
   },
   "primitive_sapling": "biomesoplenty:dead_sapling"
 }

--- a/src/main/resources/trees/dtbop/species/umbran.json
+++ b/src/main/resources/trees/dtbop/species/umbran.json
@@ -9,12 +9,9 @@
   "growth_rate": 0.9,
   "growth_logic_kit": "dtbop:small_conifer",
   "leaves_properties": "dtbop:umbran",
-  "environment_factors" : {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
-  "perfect_biomes": { "type": "coniferous" },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.3,
+  "perfect_biomes": { "tag": "#c:is_coniferous" },
   "primitive_sapling": "biomesoplenty:umbran_sapling",
   "mega_species": "dtbop:mega_umbran",
   "features" : [

--- a/src/main/resources/trees/dtbop/species/willow.json
+++ b/src/main/resources/trees/dtbop/species/willow.json
@@ -6,11 +6,14 @@
   "signal_energy": 12.0,
   "growth_rate": 0.8,
   "leaves_properties": "dtbop:willow",
-  "environment_factors" : {
-    "hot": 0.7,
-    "dry": 0.5
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.4,
+  "perfect_biomes": {
+    "tags": [
+      "#c:is_swamp",
+      "#minecraft:is_overworld"
+    ]
   },
-  "perfect_biomes": { "types": [ "swamp", "overworld" ] },
   "primitive_sapling": "biomesoplenty:willow_sapling",
   "features" : [
     {

--- a/src/main/resources/trees/dtbop/species/yellow_maple.json
+++ b/src/main/resources/trees/dtbop/species/yellow_maple.json
@@ -8,12 +8,9 @@
   "up_probability": 4,
   "growth_rate": 1.05,
   "leaves_properties": "dtbop:yellow_maple",
-  "environment_factors" : {
-    "hot": 0.5,
-    "dry": 0.5,
-    "forest": 1.05
-  },
-  "perfect_biomes": { "type": "biomesoplenty:seasonal.*" },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.3,
+  "perfect_biomes": { "name": "biomesoplenty:seasonal.*" },
   "primitive_sapling": "biomesoplenty:yellow_maple_sapling",
   "lang_overrides": {
     "seed": "Yellow Maple Samara"

--- a/src/main/resources/trees/dtbop/world_gen/feature_cancellers.json
+++ b/src/main/resources/trees/dtbop/world_gen/feature_cancellers.json
@@ -27,7 +27,7 @@
       { "name": "biomesoplenty:muskeg" }
     ]},
     "cancellers": {
-      "types": ["tree", "mushroom", "dtbop:mushroom"],
+      "types": ["tree", "fungus"],
       "namespaces": ["biomesoplenty", "minecraft"]
     }
   }

--- a/src/main/resources/trees/dynamictrees/species/dark_oak.json
+++ b/src/main/resources/trees/dynamictrees/species/dark_oak.json
@@ -9,12 +9,8 @@
   "max_branch_radius": 24,
   "growth_logic_kit": "dark_oak",
   "leaves_properties": "dark_oak",
-  "environment_factors" : {
-    "#forge:is_cold": 0.75,
-    "#forge:is_hot": 0.5,
-    "#forge:is_dry": 0.25,
-    "mushroom": 1.25
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.8,
   "perfect_biomes": { "tag": "#forge:is_spooky", "name": "minecraft:.*" },
   "primitive_sapling": "dark_oak_sapling",
   "features" : [
@@ -29,13 +25,13 @@
       "properties": {
         "only_world_gen": true,
         "gen_feature": {
-          "name": "huge_mushrooms",
+          "name": "random_predicate",
           "properties": {
-            "max_mushrooms": 1,
-            "max_attempts": 3
+            "gen_feature": "huge_mushroom",
+            "place_chance": 0.2
           }
         },
-        "biome_predicate": { "type": "spooky", "name": "minecraft:.*" }
+        "biome_predicate": { "type": "#c:is_spooky", "name": "minecraft:.*" }
       }
     },
     {


### PR DESCRIPTION
Updated dependencies to replace environment_factors after seeing these error logs:

```log
[25Jul2026 09:04:23.788] [Render thread/WARN] [com.dtteam.dynamictrees.treepack.loader.SpeciesResourceLoader/]: The "environment_factors" property has been removed. Use "preferred_climate" instead! Species dtbop:aspen.
[25Jul2026 09:04:23.788] [Render thread/ERROR] [Dynamic Trees/]: Error whilst loading type "Species" with name "dtbop:aspen": [primitive_sapling] Json element was not a json object.
[25Jul2026 09:04:23.788] [Render thread/WARN] [com.dtteam.dynamictrees.treepack.loader.SpeciesResourceLoader/]: The "environment_factors" property has been removed. Use "preferred_climate" instead! Species dtbop:alps_spruce.
```

Error messages confirmed to go away after update. I tried to match the preferred_climate and climate_tolerance values to the intent of the environment_factors.